### PR TITLE
Plan improvements

### DIFF
--- a/src/shared/Plan.ts
+++ b/src/shared/Plan.ts
@@ -23,6 +23,7 @@ export class Plan<I, O> {
   public readonly eventEmitter: EventEmitter;
   public executing: boolean = false;
   public executed: boolean = false;
+  public failed: boolean = false;
 
   private constructor(plan: InputPlan<I, O>) {
     this.promise = plan.promise;
@@ -145,8 +146,12 @@ export class Plan<I, O> {
     try {
       this.executing = true;
       this.executed = false;
+      this.failed = false;
       const state = initialState ?? (undefined as unknown as I);
       return await this.promise(state, this.steps);
+    } catch (error) {
+      this.failed = true;
+      throw error;
     } finally {
       this.executing = false;
       this.executed = true;

--- a/test/shared/Plan.test.ts
+++ b/test/shared/Plan.test.ts
@@ -189,18 +189,25 @@ test('it can listen to all step changes at once', async (t: Test) => {
 });
 
 test('it keeps track of its execution state', async (t: Test) => {
-  // Given
+  // Given a plan with a step that ensure the plan is executing.
   const plan = Plan.make().addStep({
       name: 'step1',
-      handler: async () => 42,
+      handler: async (_, plan) => {
+        t.true(plan.executing);
+        t.false(plan.executed);
+        t.false(plan.failed);
+      },
   });
 
+  // And that plan hasn't executed yet.
   t.false(plan.executing);
   t.false(plan.executed);
   t.false(plan.failed);
 
+  // When we execute the plan.
   await plan.execute();
 
+  // Then it is marked as executed.
   t.false(plan.executing);
   t.true(plan.executed);
   t.false(plan.failed);

--- a/test/shared/Plan.test.ts
+++ b/test/shared/Plan.test.ts
@@ -24,6 +24,27 @@ test('it works with one trivial step', async (t: Test) => {
   t.equal(plan.getSteps()[0].status, 'successful');
 });
 
+test('it support another signature for adding steps', async (t: Test) => {
+  // Given we add steps using the alternative signature.
+  const plan = Plan.make().addStep('step1', async () => 42, {
+    optional: true,
+    hidden: true,
+  });
+
+  // When we execute the plan.
+  const finalState = await plan.execute();
+
+  // Then we got the right value.
+  t.same(finalState, 42);
+
+  // And all step information was stored properly.
+  const step = plan.getSteps()[0];
+  t.equal(step.name, 'step1');
+  t.equal(step.status, 'successful');
+  t.true(step.optional);
+  t.true(step.hidden);
+});
+
 test('it may require some initial state', async (t: Test) => {
   // Given a plan with only one step that keep track of its execution.
   const plan = Plan.make<{ counter: number }>().addStep({
@@ -128,10 +149,7 @@ test('it can listen to step changes', async (t: Test) => {
   // Given a plan with one step that listens for changes.
   const step1Changes: string[] = [];
   const plan = Plan.make()
-    .addStep({
-      name: 'step1',
-      handler: async () => 42,
-    })
+    .addStep('step1', async () => 42)
     .onChange((step) => {
       step1Changes.push(step.status);
     });
@@ -147,14 +165,8 @@ test('it can listen to all step changes at once', async (t: Test) => {
   // Given a plan with two steps that listen for changes.
   const history: { [key: string]: string }[] = [];
   const plan = Plan.make()
-    .addStep({
-      name: 'step1',
-      handler: async () => 42,
-    })
-    .addStep({
-      name: 'step2',
-      handler: async (n) => n * 2,
-    })
+    .addStep('step1', async () => 42)
+    .addStep('step2', async (n) => n * 2)
     .onChange((step, plan) => {
       const acc = { changed: step.name };
       history.push(plan.steps.reduce((acc, step) => ({ ...acc, [step.name]: step.status }), acc));
@@ -190,13 +202,10 @@ test('it can listen to all step changes at once', async (t: Test) => {
 
 test('it keeps track of its execution state', async (t: Test) => {
   // Given a plan with a step that ensure the plan is executing.
-  const plan = Plan.make().addStep({
-      name: 'step1',
-      handler: async (_, plan) => {
-        t.true(plan.executing);
-        t.false(plan.executed);
-        t.false(plan.failed);
-      },
+  const plan = Plan.make().addStep('step1', async (_, plan) => {
+    t.true(plan.executing);
+    t.false(plan.executed);
+    t.false(plan.failed);
   });
 
   // And that plan hasn't executed yet.
@@ -215,10 +224,8 @@ test('it keeps track of its execution state', async (t: Test) => {
 
 test('it keeps track of its failed state', async (t: Test) => {
   // Given a plan that fails.
-  const plan = Plan.make().addStep({
-    name: 'step1',
-    handler: async () => { throw new Error('error') },
-  });
+  const plan = Plan.make()
+    .addStep('step1', async () => { throw new Error('error') });
 
   // And that hasn't executed yet.
   t.false(plan.executing);

--- a/test/shared/Plan.test.ts
+++ b/test/shared/Plan.test.ts
@@ -187,3 +187,50 @@ test('it can listen to all step changes at once', async (t: Test) => {
     },
   ]);
 });
+
+test('it keeps track of its execution state', async (t: Test) => {
+  // Given
+  const plan = Plan.make().addStep({
+      name: 'step1',
+      handler: async () => 42,
+  });
+
+  t.false(plan.executing);
+  t.false(plan.executed);
+  t.false(plan.failed);
+
+  await plan.execute();
+
+  t.false(plan.executing);
+  t.true(plan.executed);
+  t.false(plan.failed);
+});
+
+test('it keeps track of its failed state', async (t: Test) => {
+  // Given a plan that fails.
+  const plan = Plan.make().addStep({
+    name: 'step1',
+    handler: async () => { throw new Error('error') },
+  });
+
+  // And that hasn't executed yet.
+  t.false(plan.executing);
+  t.false(plan.executed);
+  t.false(plan.failed);
+
+  // When we execute the plan.
+  try {
+    await plan.execute();
+  }
+  
+  // Then it is marked as failed.
+  catch (error) {
+    t.false(plan.executing);
+    t.true(plan.executed);
+    t.true(plan.failed);
+    return;
+  }
+
+  // We should never get here.
+  t.fail('plan should have failed');
+});

--- a/test/shared/Plan.test.ts
+++ b/test/shared/Plan.test.ts
@@ -155,9 +155,9 @@ test('it can listen to all step changes at once', async (t: Test) => {
       name: 'step2',
       handler: async (n) => n * 2,
     })
-    .onChange((step, steps) => {
+    .onChange((step, plan) => {
       const acc = { changed: step.name };
-      history.push(steps.reduce((acc, step) => ({ ...acc, [step.name]: step.status }), acc));
+      history.push(plan.steps.reduce((acc, step) => ({ ...acc, [step.name]: step.status }), acc));
     });
 
   // When we execute the plan.


### PR DESCRIPTION
After using Plans in Peppermint, I've noticed a few pain points, that I'm fixing here.
- Keep track of failure states.
- Add a more intuitive signature for adding steps.
- Expose the Step types.
- Pass the entire plan to callback instead of its steps.