### PR TITLE
fix bundlr from node (#41)

### DIFF
--- a/src/Metaplex.ts
+++ b/src/Metaplex.ts
@@ -13,7 +13,7 @@ import {
   SendTransactionError,
   TransactionError,
 } from '@solana/web3.js';
-import { IdentityDriver, GuestIdentityDriver, StorageDriver, BundlrStorageDriver } from '@/drivers';
+import { GuestIdentityDriver, StorageDriver, BundlrStorageDriver } from '@/drivers';
 import {
   InputOfOperation,
   Operation,
@@ -39,7 +39,7 @@ export class Metaplex {
   public readonly options: MetaplexOptions;
 
   /** Encapsulates the identity of the users interacting with the SDK. */
-  protected identityDriver: IdentityDriver;
+  protected identityDriver: any;
 
   /** Encapsulates where assets should be uploaded. */
   protected storageDriver: StorageDriver;
@@ -73,7 +73,7 @@ export class Metaplex {
     return this.identityDriver;
   }
 
-  setIdentity(identity: IdentityDriver) {
+  setIdentity(identity: any) {
     this.identityDriver = identity;
 
     return this;

--- a/src/Metaplex.ts
+++ b/src/Metaplex.ts
@@ -13,7 +13,7 @@ import {
   SendTransactionError,
   TransactionError,
 } from '@solana/web3.js';
-import { GuestIdentityDriver, StorageDriver, BundlrStorageDriver } from '@/drivers';
+import { IdentityDriver, GuestIdentityDriver, StorageDriver, BundlrStorageDriver } from '@/drivers';
 import {
   InputOfOperation,
   Operation,
@@ -39,7 +39,7 @@ export class Metaplex {
   public readonly options: MetaplexOptions;
 
   /** Encapsulates the identity of the users interacting with the SDK. */
-  protected identityDriver: any;
+  protected identityDriver: IdentityDriver;
 
   /** Encapsulates where assets should be uploaded. */
   protected storageDriver: StorageDriver;
@@ -73,7 +73,7 @@ export class Metaplex {
     return this.identityDriver;
   }
 
-  setIdentity(identity: any) {
+  setIdentity(identity: IdentityDriver) {
     this.identityDriver = identity;
 
     return this;

--- a/src/drivers/storage/BundlrStorageDriver.ts
+++ b/src/drivers/storage/BundlrStorageDriver.ts
@@ -3,7 +3,7 @@ import { Metaplex } from '@/Metaplex';
 import { MetaplexPlugin } from '@/MetaplexPlugin';
 import { StorageDriver } from './StorageDriver';
 import { MetaplexFile } from '../filesystem/MetaplexFile';
-import { WalletAdapterIdentityDriver } from '../identity/WalletAdapterIdentityDriver';
+import { KeypairIdentityDriver } from '../identity/KeypairIdentityDriver'
 import { PlanUploadMetadataOperation } from '@/modules';
 import { PlanUploadMetadataUsingBundlrOperationHandler } from './PlanUploadMetadataUsingBundlrOperationHandler';
 import { SolAmount } from '@/shared';
@@ -123,10 +123,12 @@ export class BundlrStorageDriver extends StorageDriver {
       providerUrl: this.options.providerUrl,
     };
 
+    const identity = this.metaplex.identity();
+
     const bundlr =
-      this.metaplex.identity() instanceof WalletAdapterIdentityDriver
-        ? new WebBundlr(address, currency, this.metaplex.identity(), options)
-        : new NodeBundlr(address, currency, this.metaplex.identity().keypair.secretKey, options);
+      identity instanceof KeypairIdentityDriver
+        ? new NodeBundlr(address, currency, identity.keypair.secretKey, options)
+        : new WebBundlr(address, currency, identity, options);
     try {
       // Check for valid bundlr node.
       await bundlr.utils.getBundlerAddress(currency);

--- a/src/drivers/storage/BundlrStorageDriver.ts
+++ b/src/drivers/storage/BundlrStorageDriver.ts
@@ -126,8 +126,7 @@ export class BundlrStorageDriver extends StorageDriver {
     const bundlr =
       this.metaplex.identity() instanceof WalletAdapterIdentityDriver
         ? new WebBundlr(address, currency, this.metaplex.identity(), options)
-        : new NodeBundlr(address, currency, this.metaplex.identity(), options);
-
+        : new NodeBundlr(address, currency, this.metaplex.identity().keypair.secretKey, options);
     try {
       // Check for valid bundlr node.
       await bundlr.utils.getBundlerAddress(currency);


### PR DESCRIPTION
Related to issue #41 

https://github.com/metaplex-foundation/js-next/issues/41

Strictly typing the IdentityDriver to well, IdentityDriver, breaks the functionality of using the KeypairIdentityDriver. The KeypairIdentityDriver is ideal because I can batch upload and mint NFTs using uploadMetdata(). This pull request does two things:
1) Allows identityDriver to be of type any so that it can be either IdentityDriver or KeypairIdentityDriver
2) Fixes the initialization of the bundlr Client in the NodeBundlr instantiation by using the keypair.secretKey properties in the KeypairIdentityDriver class object