### PR TITLE
test: ensure createNft results in valid on-chain NFT

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+**/.git
+**/.github
+**/node_modules
+**/dist
+
+.ammanrc.js
+.prettierrc
+package.json
+tsconfig.cjs.json
+tsconfig.json
+README.md

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "amman:start": "DEBUG='amman*' amman validator",
     "amman:stop": "pkill solana-test-validator",
     "test": "yarn build:test && tape dist/test/**/*.test.js",
-    "lint": "prettier -c ./{src,test}/",
-    "lint:fix": "prettier --write ./{src,test}/"
+    "lint": "prettier -c .",
+    "lint:fix": "prettier --write ."
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.1",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "amman:start": "DEBUG='amman*' amman validator",
     "amman:stop": "pkill solana-test-validator",
     "test": "yarn build:test && tape dist/test/**/*.test.js",
-    "lint": "prettier -c ./src/",
-    "lint:fix": "prettier --write ./src"
+    "lint": "prettier -c ./{src,test}/",
+    "lint:fix": "prettier --write ./{src,test}/"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.1",

--- a/src/modules/nfts/NftClient.ts
+++ b/src/modules/nfts/NftClient.ts
@@ -20,33 +20,31 @@ import {
 } from './operations';
 
 export class NftClient extends ModuleClient {
-  async findNftByMint(mint: PublicKey): Promise<Nft> {
+  findNftByMint(mint: PublicKey): Promise<Nft> {
     return this.metaplex.execute(new FindNftByMintOperation(mint));
   }
 
-  async findNftsByMintList(mints: PublicKey[]): Promise<(Nft | null)[]> {
+  findNftsByMintList(mints: PublicKey[]): Promise<(Nft | null)[]> {
     return this.metaplex.execute(new FindNftsByMintListOperation(mints));
   }
 
-  async findNftsByOwner(owner: PublicKey): Promise<Nft[]> {
+  findNftsByOwner(owner: PublicKey): Promise<Nft[]> {
     return this.metaplex.execute(new FindNftsByOwnerOperation(owner));
   }
 
-  async findNftsByCreator(creator: PublicKey, position: number = 1): Promise<Nft[]> {
+  findNftsByCreator(creator: PublicKey, position: number = 1): Promise<Nft[]> {
     return this.metaplex.execute(new FindNftsByCreatorOperation({ creator, position }));
   }
 
-  async findNftsByCandyMachine(candyMachine: PublicKey, version?: 1 | 2): Promise<Nft[]> {
+  findNftsByCandyMachine(candyMachine: PublicKey, version?: 1 | 2): Promise<Nft[]> {
     return this.metaplex.execute(new FindNftsByCandyMachineOperation({ candyMachine, version }));
   }
 
-  async uploadMetadata(input: UploadMetadataInput): Promise<UploadMetadataOutput> {
+  uploadMetadata(input: UploadMetadataInput): Promise<UploadMetadataOutput> {
     return this.metaplex.execute(new UploadMetadataOperation(input));
   }
 
-  async planUploadMetadata(
-    input: UploadMetadataInput
-  ): Promise<Plan<undefined, UploadMetadataOutput>> {
+  planUploadMetadata(input: UploadMetadataInput): Promise<Plan<undefined, UploadMetadataOutput>> {
     return this.metaplex.execute(new PlanUploadMetadataOperation(input));
   }
 

--- a/test/drivers/storage/awsStorageDriver.test.ts
+++ b/test/drivers/storage/awsStorageDriver.test.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import test, { Test } from 'tape';
 import sinon from 'sinon';
 import { metaplex } from '../../helpers';
@@ -6,21 +6,21 @@ import { awsStorage, MetaplexFile } from '@/index';
 
 const awsClient = {
   async send() {
-    return {}
+    return {};
   },
   config: {
     async region() {
       return 'us-east';
-    }
-  }
+    },
+  },
 } as unknown as S3Client;
 
 test('it can upload assets to a S3 bucket', async (t: Test) => {
   // Given a mock awsClient.
   const stub = sinon.spy(awsClient);
 
-	// Fed to a Metaplex instance.
-	const mx = await metaplex();
+  // Fed to a Metaplex instance.
+  const mx = await metaplex();
   mx.use(awsStorage(awsClient, 'some-bucket'));
 
   // When we upload some content to AWS S3.

--- a/test/helpers/asserts.ts
+++ b/test/helpers/asserts.ts
@@ -1,6 +1,6 @@
-import { PublicKey } from "@solana/web3.js";
-import { bignum } from "@metaplex-foundation/beet";
-import BN from "bn.js";
+import { PublicKey } from '@solana/web3.js';
+import { bignum } from '@metaplex-foundation/beet';
+import BN from 'bn.js';
 import { Specification } from 'spok';
 
 export function spokSamePubkey(a: PublicKey | null): Specification<PublicKey> {

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './asserts';
 export * from './setup';
+export * from './utils';

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,38 +1,43 @@
-import { Commitment, Connection, Keypair } from "@solana/web3.js";
+import { Commitment, Connection, Keypair } from '@solana/web3.js';
 import { LOCALHOST, airdrop } from '@metaplex-foundation/amman';
-import { Metaplex, guestIdentity, keypairIdentity, mockStorage, UploadMetadataInput, CreateNftInput } from '@/index';
+import {
+  Metaplex,
+  guestIdentity,
+  keypairIdentity,
+  mockStorage,
+  UploadMetadataInput,
+  CreateNftInput,
+} from '@/index';
 
 export interface MetaplexTestOptions {
-	rpcEndpoint?: string;
-	commitment?: Commitment;
-	solsToAirdrop?: number;
+  rpcEndpoint?: string;
+  commitment?: Commitment;
+  solsToAirdrop?: number;
 }
 
 export const metaplexGuest = (options: MetaplexTestOptions = {}) => {
-	const connection = new Connection(options.rpcEndpoint ?? LOCALHOST, {
-		commitment: options.commitment ?? 'singleGossip',
-	});
+  const connection = new Connection(options.rpcEndpoint ?? LOCALHOST, {
+    commitment: options.commitment ?? 'singleGossip',
+  });
 
-	return Metaplex.make(connection)
-		.use(guestIdentity())
-		.use(mockStorage());
-}
+  return Metaplex.make(connection).use(guestIdentity()).use(mockStorage());
+};
 
 export const metaplex = async (options: MetaplexTestOptions = {}) => {
-	const wallet = Keypair.generate();
-	const mx = metaplexGuest(options).use(keypairIdentity(wallet));
-	await airdrop(mx.connection, wallet.publicKey, options.solsToAirdrop ?? 100);
+  const wallet = Keypair.generate();
+  const mx = metaplexGuest(options).use(keypairIdentity(wallet));
+  await airdrop(mx.connection, wallet.publicKey, options.solsToAirdrop ?? 100);
 
-	return mx;
-}
+  return mx;
+};
 
 export const createNft = async (
-	mx: Metaplex,
-	metadata: UploadMetadataInput = {},
-	onChain: Partial<CreateNftInput> = {},
+  mx: Metaplex,
+  metadata: UploadMetadataInput = {},
+  onChain: Partial<CreateNftInput> = {}
 ) => {
-  const { uri } = await mx.nfts().uploadMetadata(metadata)
+  const { uri } = await mx.nfts().uploadMetadata(metadata);
   const { nft } = await mx.nfts().createNft({ ...onChain, uri });
 
-	return nft;
-}
+  return nft;
+};

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,0 +1,14 @@
+import test from 'tape';
+
+/**
+ * This is a workaround the fact that web3.js doesn't close it's socket connection and provides no way to do so.
+ * Therefore the process hangs for a considerable time after the tests finish, increasing the feedback loop.
+ *
+ * This fixes this by exiting the process as soon as all tests are finished.
+ */
+export function killStuckProcess() {
+  // Don't do this in CI since we need to ensure we get a non-zero exit code if tests fail
+  if (process.env.CI == null) {
+    test.onFinish(() => process.exit(0));
+  }
+}

--- a/test/modules/nfts/createNft.test.ts
+++ b/test/modules/nfts/createNft.test.ts
@@ -3,207 +3,215 @@ import spok, { Specifications } from 'spok';
 import { Keypair } from '@solana/web3.js';
 import { UseMethod } from '@metaplex-foundation/mpl-token-metadata';
 import { JsonMetadata, MetaplexFile, Nft } from '@/index';
-import { metaplex, spokSamePubkey, spokSameBignum } from '../../helpers';
+import { metaplex, spokSamePubkey, spokSameBignum, killStuckProcess } from '../../helpers';
+
+killStuckProcess();
 
 test('it can create an NFT with minimum configuration', async (t: Test) => {
-	// Given we have a Metaplex instance.
-	const mx = await metaplex();
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
 
-	// And we uploaded an image.
-	const imageFile = new MetaplexFile('some_image', 'some-image.jpg');
-	const imageUri = await mx.storage().upload(imageFile);
+  // And we uploaded an image.
+  const imageFile = new MetaplexFile('some_image', 'some-image.jpg');
+  const imageUri = await mx.storage().upload(imageFile);
 
-	// And we uploaded some metadata containing this image.
-	const metadataUri = await mx.storage().uploadJson<JsonMetadata>({
-		name: 'JSON NFT name',
-		description: 'JSON NFT description',
-		image: imageUri,
-	});
+  // And we uploaded some metadata containing this image.
+  const metadataUri = await mx.storage().uploadJson<JsonMetadata>({
+    name: 'JSON NFT name',
+    description: 'JSON NFT description',
+    image: imageUri,
+  });
 
-	// When we create a new NFT with minimum configuration.
-	const { nft } = await mx.nfts().createNft({
-		name: 'On-chain NFT name',
-		uri: metadataUri,
-	});
+  // When we create a new NFT with minimum configuration.
+  const { nft } = await mx.nfts().createNft({
+    uri: metadataUri,
+    name: 'On-chain NFT name',
+  });
 
-	// Then we created and retrieved the new NFT and it has appropriate defaults.
-	spok(t, nft, {
-		$topic: 'nft',
-		name: 'On-chain NFT name',
-		uri: metadataUri,
-		metadata: {
-			name: 'JSON NFT name',
-			description: 'JSON NFT description',
-			image: imageUri,
-		},
-		sellerFeeBasisPoints: 500,
-		primarySaleHappened: false,
-		updateAuthority: spokSamePubkey(mx.identity().publicKey),
-		creators: [
-			{
-				address: spokSamePubkey(mx.identity().publicKey),
-				share: 100,
-				verified: true,
-			},
-		],
-		collection: null,
-		uses: null,
-	} as unknown as Specifications<Nft>);
+  // Then we created and returned the new NFT and it has appropriate defaults.
+  const expectedNft = {
+    name: 'On-chain NFT name',
+    uri: metadataUri,
+    metadata: {
+      name: 'JSON NFT name',
+      description: 'JSON NFT description',
+      image: imageUri,
+    },
+    sellerFeeBasisPoints: 500,
+    primarySaleHappened: false,
+    updateAuthority: spokSamePubkey(mx.identity().publicKey),
+    creators: [
+      {
+        address: spokSamePubkey(mx.identity().publicKey),
+        share: 100,
+        verified: true,
+      },
+    ],
+    collection: null,
+    uses: null,
+  } as unknown as Specifications<Nft>;
+  spok(t, nft, { $topic: 'nft', ...expectedNft });
+
+  // When we then retrieve that NFT.
+  const retrievedNft = await mx.nfts().findNftByMint(nft.mint);
+
+  // Then it matches what createNft returned.
+  spok(t, retrievedNft, { $topic: 'Retrieved Nft', ...expectedNft });
 });
 
 test('it can create an NFT with maximum configuration', async (t: Test) => {
-	// Given we have a Metaplex instance.
-	const mx = await metaplex();
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
 
-	// And we uploaded some metadata.
-	const { uri, metadata } = await mx.nfts().uploadMetadata({
-		name: 'JSON NFT name',
-		description: 'JSON NFT description',
-		image: new MetaplexFile('some_image', 'some-image.jpg'),
-	});
+  // And we uploaded some metadata.
+  const { uri, metadata } = await mx.nfts().uploadMetadata({
+    name: 'JSON NFT name',
+    description: 'JSON NFT description',
+    image: new MetaplexFile('some_image', 'some-image.jpg'),
+  });
 
-	// And a various keypairs for different access.
-	const mint = Keypair.generate();
-	const collection = Keypair.generate();
-	const owner = Keypair.generate();
-	const mintAuthority = Keypair.generate();
-	const updateAuthority = Keypair.generate();
-	const otherCreator = Keypair.generate();
+  // And a various keypairs for different access.
+  const mint = Keypair.generate();
+  const collection = Keypair.generate();
+  const owner = Keypair.generate();
+  const mintAuthority = Keypair.generate();
+  const updateAuthority = Keypair.generate();
+  const otherCreator = Keypair.generate();
 
-	// When we create a new NFT with minimum configuration.
-	const { nft } = await mx.nfts().createNft({
-		uri,
-		name: 'On-chain NFT name',
-		symbol: 'MYNFT',
-		sellerFeeBasisPoints: 456,
-		isMutable: true,
-		maxSupply: 123,
-		mint: mint,
-		payer: mx.identity(),
-		mintAuthority: mintAuthority,
-		updateAuthority: updateAuthority,
-		owner: owner.publicKey,
-		// Must be the same as mint authority.
-		// https://github.com/metaplex-foundation/metaplex-program-library/blob/c0bf49d416d6aaf5aa9db999343b20be720df67a/token-metadata/program/src/utils.rs#L346
-		freezeAuthority: mintAuthority.publicKey,
-		collection: {
-			verified: false,
-			key: collection.publicKey,
-		},
-		uses: {
-			useMethod: UseMethod.Burn,
-			remaining: 0,
-			total: 1000,
-		},
-		creators: [
-			{
-				address: updateAuthority.publicKey,
-				share: 60,
-				verified: true,
-			},
-			{
-				address: otherCreator.publicKey,
-				share: 40,
-				verified: false,
-			},
-		],
-	});
+  // When we create a new NFT with minimum configuration.
+  const { nft } = await mx.nfts().createNft({
+    uri,
+    name: 'On-chain NFT name',
+    symbol: 'MYNFT',
+    sellerFeeBasisPoints: 456,
+    isMutable: true,
+    maxSupply: 123,
+    mint: mint,
+    payer: mx.identity(),
+    mintAuthority: mintAuthority,
+    updateAuthority: updateAuthority,
+    owner: owner.publicKey,
+    // Must be the same as mint authority.
+    // https://github.com/metaplex-foundation/metaplex-program-library/blob/c0bf49d416d6aaf5aa9db999343b20be720df67a/token-metadata/program/src/utils.rs#L346
+    freezeAuthority: mintAuthority.publicKey,
+    collection: {
+      verified: false,
+      key: collection.publicKey,
+    },
+    uses: {
+      useMethod: UseMethod.Burn,
+      remaining: 0,
+      total: 1000,
+    },
+    creators: [
+      {
+        address: updateAuthority.publicKey,
+        share: 60,
+        verified: true,
+      },
+      {
+        address: otherCreator.publicKey,
+        share: 40,
+        verified: false,
+      },
+    ],
+  });
 
-	// Then we created and retrieved the new NFT and it has appropriate defaults.
-	spok(t, nft, {
-		$topic: 'nft',
-		name: 'On-chain NFT name',
-		uri: spok.string,
-		metadata: {
-			name: 'JSON NFT name',
-			description: 'JSON NFT description',
-			image: metadata.image,
-		},
-		sellerFeeBasisPoints: 456,
-		primarySaleHappened: false,
-		updateAuthority: spokSamePubkey(updateAuthority.publicKey),
-		collection: {
-			verified: false,
-			key: spokSamePubkey(collection.publicKey),
-		},
-		uses: {
-			useMethod: UseMethod.Burn,
-			remaining: spokSameBignum(0),
-			total: spokSameBignum(1000),
-		},
-		creators: [
-			{
-				address: spokSamePubkey(updateAuthority.publicKey),
-				share: 60,
-				verified: true,
-			},
-			{
-				address: spokSamePubkey(otherCreator.publicKey),
-				share: 40,
-				verified: false,
-			},
-		],
-	} as unknown as Specifications<Nft>);
+  // Then we created and retrieved the new NFT and it has appropriate defaults.
+  spok(t, nft, {
+    $topic: 'nft',
+    name: 'On-chain NFT name',
+    uri: spok.string,
+    metadata: {
+      name: 'JSON NFT name',
+      description: 'JSON NFT description',
+      image: metadata.image,
+    },
+    sellerFeeBasisPoints: 456,
+    primarySaleHappened: false,
+    updateAuthority: spokSamePubkey(updateAuthority.publicKey),
+    collection: {
+      verified: false,
+      key: spokSamePubkey(collection.publicKey),
+    },
+    uses: {
+      useMethod: UseMethod.Burn,
+      remaining: spokSameBignum(0),
+      total: spokSameBignum(1000),
+    },
+    creators: [
+      {
+        address: spokSamePubkey(updateAuthority.publicKey),
+        share: 60,
+        verified: true,
+      },
+      {
+        address: spokSamePubkey(otherCreator.publicKey),
+        share: 40,
+        verified: false,
+      },
+    ],
+  } as unknown as Specifications<Nft>);
 });
 
 test('it fill missing on-chain data from the JSON metadata', async (t: Test) => {
-	// Given we have a Metaplex instance.
-	const mx = await metaplex();
+  // Given we have a Metaplex instance.
+  const mx = await metaplex();
 
-	// And we uploaded some metadata.
-	const creatorA = Keypair.generate().publicKey;
-	const creatorB = Keypair.generate().publicKey;
-	const { uri, metadata } = await mx.nfts().uploadMetadata({
-		name: 'JSON NFT name',
-		symbol: 'MYNFT',
-		description: 'JSON NFT description',
-		image: new MetaplexFile('some_image', 'some-image.jpg'),
-		seller_fee_basis_points: 456,
-		properties: {
-			creators: [
-				{
-					address: mx.identity().publicKey.toBase58(),
-					share: 50,
-				},
-				{
-					address: creatorA.toBase58(),
-					share: 30,
-				},
-				{
-					address: creatorB.toBase58(),
-					share: 20,
-				},
-			]
-		}
-	});
+  // And we uploaded some metadata.
+  const creatorA = Keypair.generate().publicKey;
+  const creatorB = Keypair.generate().publicKey;
+  const { uri, metadata } = await mx.nfts().uploadMetadata({
+    name: 'JSON NFT name',
+    symbol: 'MYNFT',
+    description: 'JSON NFT description',
+    image: new MetaplexFile('some_image', 'some-image.jpg'),
+    seller_fee_basis_points: 456,
+    properties: {
+      creators: [
+        {
+          address: mx.identity().publicKey.toBase58(),
+          share: 50,
+        },
+        {
+          address: creatorA.toBase58(),
+          share: 30,
+        },
+        {
+          address: creatorB.toBase58(),
+          share: 20,
+        },
+      ],
+    },
+  });
 
-	// When we create a new NFT using that JSON metadata only.
-	const { nft } = await mx.nfts().createNft({ uri });
+  // When we create a new NFT using that JSON metadata only.
+  const { nft } = await mx.nfts().createNft({ uri });
 
-	// Then the created NFT used some of the JSON metadata to fill some on-chain data.
-	spok(t, nft, {
-		$topic: 'nft',
-		name: 'JSON NFT name',
-		symbol: 'MYNFT',
-		uri,
-		metadata,
-		sellerFeeBasisPoints: 456,
-		creators: [
-			{
-				address: spokSamePubkey(mx.identity().publicKey),
-				share: 50,
-				verified: true,
-			},
-			{
-				address: spokSamePubkey(creatorA),
-				share: 30,
-				verified: false,
-			},
-			{
-				address: spokSamePubkey(creatorB),
-				share: 20,
-				verified: false,
-			},
-		],
-	} as unknown as Specifications<Nft>);
+  // Then the created NFT used some of the JSON metadata to fill some on-chain data.
+  spok(t, nft, {
+    $topic: 'nft',
+    name: 'JSON NFT name',
+    symbol: 'MYNFT',
+    uri,
+    metadata,
+    sellerFeeBasisPoints: 456,
+    creators: [
+      {
+        address: spokSamePubkey(mx.identity().publicKey),
+        share: 50,
+        verified: true,
+      },
+      {
+        address: spokSamePubkey(creatorA),
+        share: 30,
+        verified: false,
+      },
+      {
+        address: spokSamePubkey(creatorB),
+        share: 20,
+        verified: false,
+      },
+    ],
+  } as unknown as Specifications<Nft>);
 });

--- a/test/modules/nfts/findNftsByCreatorOnChain.test.ts
+++ b/test/modules/nfts/findNftsByCreatorOnChain.test.ts
@@ -15,12 +15,18 @@ test('it can fetch all NFTs from the first creator', async (t: Test) => {
   const nftsA = await mx.nfts().findNftsByCreator(creatorA);
 
   // Then we don't get the NFTs from creator B.
-  t.same(nftsA.map(nft => nft.name), ['NFT A']);
+  t.same(
+    nftsA.map((nft) => nft.name),
+    ['NFT A']
+  );
   t.true(nftsA[0].is(nftA));
 
   // And vice versa.
   const nftsB = await mx.nfts().findNftsByCreator(creatorB);
-  t.same(nftsB.map(nft => nft.name), ['NFT B']);
+  t.same(
+    nftsB.map((nft) => nft.name),
+    ['NFT B']
+  );
   t.true(nftsB[0].is(nftB));
 });
 
@@ -36,25 +42,43 @@ test('it can fetch all NFTs from other creator positions', async (t: Test) => {
   const nftsA = await mx.nfts().findNftsByCreator(creatorA, 2);
 
   // Then we don't get the NFTs from second creator B.
-  t.same(nftsA.map(nft => nft.name), ['NFT A']);
+  t.same(
+    nftsA.map((nft) => nft.name),
+    ['NFT A']
+  );
   t.true(nftsA[0].is(nftA));
 
   // And vice versa.
   const nftsB = await mx.nfts().findNftsByCreator(creatorB, 2);
-  t.same(nftsB.map(nft => nft.name), ['NFT B']);
+  t.same(
+    nftsB.map((nft) => nft.name),
+    ['NFT B']
+  );
   t.true(nftsB[0].is(nftB));
 });
 
 const createNftWithFirstCreator = (mx: Metaplex, name: string, creator: PublicKey) => {
-  return createNft(mx, { name }, { creators: [
-    { address: creator, share: 50, verified: false },
-    { address: mx.identity().publicKey, share: 50, verified: true },
-  ] });
-}
+  return createNft(
+    mx,
+    { name },
+    {
+      creators: [
+        { address: creator, share: 50, verified: false },
+        { address: mx.identity().publicKey, share: 50, verified: true },
+      ],
+    }
+  );
+};
 
 const createNftWithSecondCreator = (mx: Metaplex, name: string, creator: PublicKey) => {
-  return createNft(mx, { name }, { creators: [
-    { address: mx.identity().publicKey, share: 50, verified: true },
-    { address: creator, share: 50, verified: false },
-  ] });
-}
+  return createNft(
+    mx,
+    { name },
+    {
+      creators: [
+        { address: mx.identity().publicKey, share: 50, verified: true },
+        { address: creator, share: 50, verified: false },
+      ],
+    }
+  );
+};

--- a/test/modules/nfts/findNftsByMintListOnChain.test.ts
+++ b/test/modules/nfts/findNftsByMintListOnChain.test.ts
@@ -12,7 +12,10 @@ test('it can fetch all NFTs from a provided mint list', async (t: Test) => {
   const nfts = await mx.nfts().findNftsByMintList([nftA.mint, nftB.mint]);
 
   // Then we get the right NFTs.
-  t.same(nfts.map(nft => nft?.name), ['NFT A', 'NFT B']);
+  t.same(
+    nfts.map((nft) => nft?.name),
+    ['NFT A', 'NFT B']
+  );
   t.true(nfts[0]?.is(nftA));
   t.true(nfts[1]?.is(nftB));
 });
@@ -27,14 +30,13 @@ test('it can fetch all NFTs from a provided mint list', async (t: Test) => {
   const emptyMintB = Keypair.generate().publicKey;
 
   // When we fetch NFTs matching all these addresses.
-  const nfts = await mx.nfts().findNftsByMintList([
-    emptyMintA,
-    nft.mint,
-    emptyMintB,
-  ]);
+  const nfts = await mx.nfts().findNftsByMintList([emptyMintA, nft.mint, emptyMintB]);
 
   // Then we get null for mint not associated to any NFT.
-  t.same(nfts.map(nft => nft?.name ?? null), [null, 'Some NFT', null]);
+  t.same(
+    nfts.map((nft) => nft?.name ?? null),
+    [null, 'Some NFT', null]
+  );
 });
 
 test('it does not load the NFT metadata or master edition by default', async (t: Test) => {

--- a/test/modules/nfts/findNftsByOwnerOnChain.test.ts
+++ b/test/modules/nfts/findNftsByOwnerOnChain.test.ts
@@ -14,9 +14,9 @@ test('it can fetch all NFTs in a wallet', async (t: Test) => {
   const nfts = await mx.nfts().findNftsByOwner(owner);
 
   // Then we get the right NFTs.
-  t.same(nfts.map(nft => nft.name).sort(), ['NFT A', 'NFT B']);
-  t.same(nfts.map(nft => nft.mint.toBase58()).sort(), [
-    nftA.mint.toBase58(),
-    nftB.mint.toBase58()
-  ].sort());
+  t.same(nfts.map((nft) => nft.name).sort(), ['NFT A', 'NFT B']);
+  t.same(
+    nfts.map((nft) => nft.mint.toBase58()).sort(),
+    [nftA.mint.toBase58(), nftB.mint.toBase58()].sort()
+  );
 });

--- a/test/modules/nfts/updateNft.test.ts
+++ b/test/modules/nfts/updateNft.test.ts
@@ -8,14 +8,18 @@ test('it can update the on-chain data of an nft', async (t: Test) => {
   const mx = await metaplex();
 
   // And an existing NFT.
-  const nft = await createNft(mx, {
-    name: 'JSON NFT name',
-    description: 'JSON NFT description',
-    image: new MetaplexFile('some image', 'some-image.jpg'),
-  }, {
-    name: 'On-chain NFT name',
-    isMutable: true,
-  });
+  const nft = await createNft(
+    mx,
+    {
+      name: 'JSON NFT name',
+      description: 'JSON NFT description',
+      image: new MetaplexFile('some image', 'some-image.jpg'),
+    },
+    {
+      name: 'On-chain NFT name',
+      isMutable: true,
+    }
+  );
 
   // And some new updated metadata that has been uploadeds.
   const { uri: updatedUri, metadata: updatedMetadata } = await mx.nfts().uploadMetadata({

--- a/test/shared/Loader.test.ts
+++ b/test/shared/Loader.test.ts
@@ -55,10 +55,8 @@ test('it can fail', async (t: Test) => {
   // When we load the loader.
   try {
     await loader.load(mx);
-  }
-  
-  // Then the loader is marked as failed and we kept track of the error.
-  catch (error) {
+  } catch (error) {
+    // Then the loader is marked as failed and we kept track of the error.
     t.equal(loader.getStatus(), 'failed');
     t.equal(loader.getResult(), undefined);
     t.equal(loader.getError(), error);
@@ -80,7 +78,7 @@ test('it can fail silently', async (t: Test) => {
   // When we load the loader using the "failSilently" option
   // outside of a try/catch.
   await loader.load(mx, { failSilently: true });
-  
+
   // Then execution continues but the loader was marked as failed
   // and we kept track of the error.
   t.equal(loader.getStatus(), 'failed');
@@ -95,7 +93,7 @@ test('it can be aborted using an AbortController', async (t: Test) => {
 
   // And a test loader that returns a number after 100ms.
   const loader = new TestLoader(async () => {
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
     return 42;
   });
 
@@ -125,7 +123,7 @@ test('it can be reset', async (t: Test) => {
 
   // When we reset the loader.
   loader.reset();
-  
+
   // Then the loader was marked as pending.
   t.equal(loader.getStatus(), 'pending');
   t.equal(loader.getResult(), undefined);

--- a/test/shared/Plan.test.ts
+++ b/test/shared/Plan.test.ts
@@ -81,7 +81,7 @@ test('it works with multiple steps', async (t: Test) => {
 
 test('it keeps track of an execution state', async (t: Test) => {
   // Given a plan with an initial state altered by its steps.
-  const plan = Plan.make<{ step1Executed: boolean, step2Executed: boolean }>()
+  const plan = Plan.make<{ step1Executed: boolean; step2Executed: boolean }>()
     .addStep({
       name: 'step1',
       handler: async (state) => ({ ...state, step1Executed: true }),
@@ -106,7 +106,7 @@ test('it can grow its execution state as we add more steps', async (t: Test) => 
   const plan = Plan.make().addStep({
     name: 'step1',
     handler: async () => ({ step1Executed: true }),
-  })
+  });
 
   // And a second step that adds some more state to the plan.
   const newPlan = plan.addStep({
@@ -141,8 +141,14 @@ test('it can prepend steps to the plan', async (t: Test) => {
   t.same(finalState, { isEven: true });
 
   // And both steps executed in the right order.
-  t.same(newPlan.getSteps().map((s) => s.name), ['step0', 'step1']);
-  t.same(newPlan.getSteps().map((s) => s.status), ['successful', 'successful']);
+  t.same(
+    newPlan.getSteps().map((s) => s.name),
+    ['step0', 'step1']
+  );
+  t.same(
+    newPlan.getSteps().map((s) => s.status),
+    ['successful', 'successful']
+  );
 });
 
 test('it can listen to step changes', async (t: Test) => {
@@ -224,8 +230,9 @@ test('it keeps track of its execution state', async (t: Test) => {
 
 test('it keeps track of its failed state', async (t: Test) => {
   // Given a plan that fails.
-  const plan = Plan.make()
-    .addStep('step1', async () => { throw new Error('error') });
+  const plan = Plan.make().addStep('step1', async () => {
+    throw new Error('error');
+  });
 
   // And that hasn't executed yet.
   t.false(plan.executing);
@@ -235,10 +242,8 @@ test('it keeps track of its failed state', async (t: Test) => {
   // When we execute the plan.
   try {
     await plan.execute();
-  }
-  
-  // Then it is marked as failed.
-  catch (error) {
+  } catch (error) {
+    // Then it is marked as failed.
     t.false(plan.executing);
     t.true(plan.executed);
     t.true(plan.failed);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "removeComments": false,
-    "jsx": "preserve",
+    "jsx": "preserve"
   },
   "typedocOptions": {
     "entryPoints": "src/index.ts",


### PR DESCRIPTION
## Summary

This is an example of how we'd verify that an NFT actually is present on-chain vs.
only verifying that our methods _return_ the correct NFT.

The other tests should be updated siimilarly.

FIXES: #49

## Chores

I'm including a few minor changes I applied for issues I ran into while working on this.

- remove unnecessary `async` inside NftClient
- fixing invalid comma in tsconfig
- test util to exit test runner ASAP
