### PR TITLE
Add sendTransaction to WalletAdapterIdentityDriver

### DIFF
--- a/src/drivers/identity/WalletAdapterIdentityDriver.ts
+++ b/src/drivers/identity/WalletAdapterIdentityDriver.ts
@@ -1,4 +1,4 @@
-import { PublicKey, Transaction } from '@solana/web3.js';
+import { Connection, PublicKey, Transaction, TransactionSignature } from '@solana/web3.js';
 import {
   MessageSignerWalletAdapterProps,
   SignerWalletAdapterProps,
@@ -12,6 +12,7 @@ import {
   OperationNotSupportedByWalletAdapterError,
   UninitializedWalletAdapterError,
 } from '@/errors';
+import { SendTransactionOptions } from '@solana/wallet-adapter-base';
 
 type WalletAdapter = BaseWalletAdapter &
   Partial<MessageSignerWalletAdapterProps> &
@@ -71,5 +72,17 @@ export class WalletAdapterIdentityDriver extends IdentityDriver {
     }
 
     return this.walletAdapter.signAllTransactions(transactions);
+  }
+
+  public async sendTransaction(
+    transaction: Transaction,
+    connection: Connection,
+    options?: SendTransactionOptions
+  ): Promise<TransactionSignature> {
+    if (this.walletAdapter.sendTransaction === undefined) {
+      throw new OperationNotSupportedByWalletAdapterError('sendTransaction');
+    }
+
+    return this.walletAdapter.sendTransaction(transaction, connection, options);
   }
 }


### PR DESCRIPTION
I've been doing more work with Bundlr in web clients, and noticed that funding fails with the `WalletAdapterIdentityDriver`, because Bundlr relies on the existence of the `sendTransaction` method:

<img width="383" alt="Screen Shot 2022-04-22 at 2 01 59 PM" src="https://user-images.githubusercontent.com/89115113/164773472-6419d50d-0031-4b00-a3da-991a2b197085.png">

The call is here:
https://github.com/Bundlr-Network/js-client/blob/bc2104cf3cc89a5f428828764b818619c4c9a4c1/src/web/currencies/solana.ts#L102

It seemed harmless enough to add this as an additional optional wallet adapter method.