### PR TITLE
Move getProgramAccount to RpcDrivers

### DIFF
--- a/src/drivers/rpc/RpcDriver.ts
+++ b/src/drivers/rpc/RpcDriver.ts
@@ -1,6 +1,7 @@
 import {
   Commitment,
   ConfirmOptions,
+  GetProgramAccountsConfig,
   PublicKey,
   RpcResponseAndContext,
   SendOptions,
@@ -8,7 +9,7 @@ import {
   Transaction,
   TransactionSignature,
 } from '@solana/web3.js';
-import { Signer, TransactionBuilder, UnparsedMaybeAccount } from '@/shared';
+import { Signer, TransactionBuilder, UnparsedAccount, UnparsedMaybeAccount } from '@/shared';
 import { Driver } from '../Driver';
 
 export type ConfirmTransactionResponse = RpcResponseAndContext<SignatureResult>;
@@ -44,4 +45,9 @@ export abstract class RpcDriver extends Driver {
     publicKeys: PublicKey[],
     commitment?: Commitment
   ): Promise<UnparsedMaybeAccount[]>;
+
+  public abstract getProgramAccounts(
+    programId: PublicKey,
+    configOrCommitment?: GetProgramAccountsConfig | Commitment
+  ): Promise<UnparsedAccount[]>;
 }

--- a/src/drivers/rpc/Web3RpcDriver.ts
+++ b/src/drivers/rpc/Web3RpcDriver.ts
@@ -3,12 +3,19 @@ import {
   Blockhash,
   Commitment,
   ConfirmOptions,
+  GetProgramAccountsConfig,
   PublicKey,
   SendOptions,
   Transaction,
   TransactionSignature,
 } from '@solana/web3.js';
-import { getSignerHistogram, Signer, TransactionBuilder, UnparsedMaybeAccount } from '@/shared';
+import {
+  getSignerHistogram,
+  Signer,
+  TransactionBuilder,
+  UnparsedAccount,
+  UnparsedMaybeAccount,
+} from '@/shared';
 import {
   RpcDriver,
   ConfirmTransactionResponse,
@@ -104,6 +111,21 @@ export class Web3RpcDriver extends RpcDriver {
     return zipMap(publicKeys, accountInfos, (publicKey, accountInfo) => {
       return this.getUnparsedMaybeAccount(publicKey, accountInfo);
     });
+  }
+
+  async getProgramAccounts(
+    programId: PublicKey,
+    configOrCommitment?: GetProgramAccountsConfig | Commitment
+  ): Promise<UnparsedAccount[]> {
+    const accounts = await this.metaplex.connection.getProgramAccounts(
+      programId,
+      configOrCommitment
+    );
+
+    return accounts.map(({ pubkey, account }) => ({
+      publicKey: pubkey,
+      ...account,
+    }));
   }
 
   protected async getLatestBlockhash(): Promise<Blockhash> {

--- a/src/modules/nfts/operationHandlers/findNftsByCreatorOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByCreatorOnChainOperationHandler.ts
@@ -9,7 +9,7 @@ export const findNftsByCreatorOnChainOperationHandler: OperationHandler<FindNfts
     handle: async (operation: FindNftsByCreatorOperation, metaplex: Metaplex): Promise<Nft[]> => {
       const { creator, position = 1 } = operation.input;
 
-      const mints = await TokenMetadataProgram.metadataV1Accounts(metaplex.connection)
+      const mints = await TokenMetadataProgram.metadataV1Accounts(metaplex)
         .selectMint()
         .whereCreator(position, creator)
         .getDataAsPublicKeys();

--- a/src/modules/nfts/operationHandlers/findNftsByMintListOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByMintListOnChainOperationHandler.ts
@@ -13,7 +13,7 @@ export const findNftsByMintListOnChainOperationHandler: OperationHandler<FindNft
     ): Promise<(Nft | null)[]> => {
       const mints = operation.input;
       const metadataPdas = await Promise.all(mints.map((mint) => MetadataAccount.pda(mint)));
-      const metadataInfos = await GmaBuilder.make(metaplex.connection, metadataPdas).get();
+      const metadataInfos = await GmaBuilder.make(metaplex, metadataPdas).get();
 
       return zipMap(metadataPdas, metadataInfos, (metadataPda, metadataInfo) => {
         if (!metadataInfo || !metadataInfo.exists) return null;

--- a/src/modules/nfts/operationHandlers/findNftsByOwnerOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByOwnerOnChainOperationHandler.ts
@@ -8,7 +8,7 @@ export const findNftsByOwnerOnChainOperationHandler: OperationHandler<FindNftsBy
   handle: async (operation: FindNftsByOwnerOperation, metaplex: Metaplex): Promise<Nft[]> => {
     const owner = operation.input;
 
-    const mints = await TokenProgram.tokenAccounts(metaplex.connection)
+    const mints = await TokenProgram.tokenAccounts(metaplex)
       .selectMint()
       .whereOwner(owner)
       .whereAmount(1)

--- a/src/programs/token/TokenProgram.ts
+++ b/src/programs/token/TokenProgram.ts
@@ -1,19 +1,19 @@
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { Connection } from '@solana/web3.js';
 import { TokenProgramGpaBuilder } from './gpaBuilders';
+import { Metaplex } from '@/Metaplex';
 
 export const TokenProgram = {
   publicKey: TOKEN_PROGRAM_ID,
 
-  accounts(connection: Connection) {
-    return new TokenProgramGpaBuilder(connection, this.publicKey);
+  accounts(metaplex: Metaplex) {
+    return new TokenProgramGpaBuilder(metaplex, this.publicKey);
   },
 
-  mintAccounts(connection: Connection) {
-    return this.accounts(connection).mintAccounts();
+  mintAccounts(metaplex: Metaplex) {
+    return this.accounts(metaplex).mintAccounts();
   },
 
-  tokenAccounts(connection: Connection) {
-    return this.accounts(connection).tokenAccounts();
+  tokenAccounts(metaplex: Metaplex) {
+    return this.accounts(metaplex).tokenAccounts();
   },
 };

--- a/src/programs/tokenMetadata/TokenMetadataProgram.ts
+++ b/src/programs/tokenMetadata/TokenMetadataProgram.ts
@@ -1,15 +1,15 @@
-import { Connection } from '@solana/web3.js';
 import { PROGRAM_ID } from '@metaplex-foundation/mpl-token-metadata';
 import { TokenMetadataGpaBuilder } from './gpaBuilders';
+import { Metaplex } from '@/Metaplex';
 
 export const TokenMetadataProgram = {
   publicKey: PROGRAM_ID,
 
-  accounts(connection: Connection) {
-    return new TokenMetadataGpaBuilder(connection, this.publicKey);
+  accounts(metaplex: Metaplex) {
+    return new TokenMetadataGpaBuilder(metaplex, this.publicKey);
   },
 
-  metadataV1Accounts(connection: Connection) {
-    return this.accounts(connection).metadataV1Accounts();
+  metadataV1Accounts(metaplex: Metaplex) {
+    return this.accounts(metaplex).metadataV1Accounts();
   },
 };


### PR DESCRIPTION
The aim of this PR is to move any usage of `getProgramAccount` or `getMultipleAccountInfos` to the RpcDriver to provide a single point of failure that can be use to catch errors and re-throw them with more context.