### PR TITLE
Push operation logic to an OperationDriver

### DIFF
--- a/src/Metaplex.ts
+++ b/src/Metaplex.ts
@@ -66,7 +66,7 @@ export class Metaplex {
     return this.identityDriver;
   }
 
-  setIdentity(identity: IdentityDriver) {
+  setIdentityDriver(identity: IdentityDriver) {
     this.identityDriver = identity;
 
     return this;
@@ -76,7 +76,7 @@ export class Metaplex {
     return this.storageDriver;
   }
 
-  setStorage(storage: StorageDriver) {
+  setStorageDriver(storage: StorageDriver) {
     this.storageDriver = storage;
 
     return this;
@@ -86,7 +86,7 @@ export class Metaplex {
     return this.rpcDriver;
   }
 
-  setRpc(rpc: RpcDriver) {
+  setRpcDriver(rpc: RpcDriver) {
     this.rpcDriver = rpc;
 
     return this;
@@ -96,7 +96,7 @@ export class Metaplex {
     return this.programDriver;
   }
 
-  setPrograms(programDriver: ProgramDriver) {
+  setProgramDriver(programDriver: ProgramDriver) {
     this.programDriver = programDriver;
 
     return this;
@@ -106,7 +106,7 @@ export class Metaplex {
     return this.operationDriver;
   }
 
-  setOperations(operationDriver: OperationDriver) {
+  setOperationDriver(operationDriver: OperationDriver) {
     this.operationDriver = operationDriver;
 
     return this;

--- a/src/Metaplex.ts
+++ b/src/Metaplex.ts
@@ -8,13 +8,12 @@ import {
   Web3RpcDriver,
   ProgramDriver,
   ArrayProgramDriver,
-  coreProgramsPlugin,
   OperationDriver,
   MapOperationDriver,
 } from '@/drivers';
 import { Cluster, resolveClusterFromConnection } from '@/shared';
-import { nftPlugin } from '@/modules';
-import { MetaplexPlugin } from '@/MetaplexPlugin';
+import { MetaplexPlugin } from './MetaplexPlugin';
+import { corePlugin } from './corePlugin';
 
 export type MetaplexOptions = {
   cluster?: Cluster;
@@ -50,16 +49,11 @@ export class Metaplex {
     this.rpcDriver = new Web3RpcDriver(this);
     this.programDriver = new ArrayProgramDriver(this);
     this.operationDriver = new MapOperationDriver(this);
-    this.registerDefaultPlugins();
+    this.use(corePlugin());
   }
 
   static make(connection: Connection, options: MetaplexOptions = {}) {
     return new this(connection, options);
-  }
-
-  registerDefaultPlugins() {
-    this.use(coreProgramsPlugin);
-    this.use(nftPlugin());
   }
 
   use(plugin: MetaplexPlugin) {

--- a/src/Metaplex.ts
+++ b/src/Metaplex.ts
@@ -9,21 +9,12 @@ import {
   ProgramDriver,
   ArrayProgramDriver,
   coreProgramsPlugin,
+  OperationDriver,
+  MapOperationDriver,
 } from '@/drivers';
-import {
-  Cluster,
-  resolveClusterFromConnection,
-  OperationConstructor,
-  Operation,
-  KeyOfOperation,
-  InputOfOperation,
-  OutputOfOperation,
-  OperationHandler,
-} from '@/shared';
+import { Cluster, resolveClusterFromConnection } from '@/shared';
 import { nftPlugin } from '@/modules';
 import { MetaplexPlugin } from '@/MetaplexPlugin';
-import { Task, TaskOptions, useTask } from './shared/useTask';
-import { OperationHandlerMissingError } from '@/errors';
 
 export type MetaplexOptions = {
   cluster?: Cluster;
@@ -48,8 +39,8 @@ export class Metaplex {
   /** Registers all recognised programs across clusters. */
   protected programDriver: ProgramDriver;
 
-  /** The registered handlers for read/write operations. */
-  protected operationHandlers: Map<string, OperationHandler<any, any, any, any>> = new Map();
+  /** Registers handlers for read/write operations. */
+  protected operationDriver: OperationDriver;
 
   constructor(connection: Connection, options: MetaplexOptions = {}) {
     this.connection = connection;
@@ -58,6 +49,7 @@ export class Metaplex {
     this.storageDriver = new BundlrStorageDriver(this);
     this.rpcDriver = new Web3RpcDriver(this);
     this.programDriver = new ArrayProgramDriver(this);
+    this.operationDriver = new MapOperationDriver(this);
     this.registerDefaultPlugins();
   }
 
@@ -116,56 +108,13 @@ export class Metaplex {
     return this;
   }
 
-  register<
-    T extends Operation<K, I, O>,
-    K extends string = KeyOfOperation<T>,
-    I = InputOfOperation<T>,
-    O = OutputOfOperation<T>
-  >(
-    operationConstructor: OperationConstructor<T, K, I, O>,
-    operationHandler: OperationHandler<T, K, I, O>
-  ) {
-    this.operationHandlers.set(operationConstructor.key, operationHandler);
+  operations() {
+    return this.operationDriver;
+  }
+
+  setOperations(operationDriver: OperationDriver) {
+    this.operationDriver = operationDriver;
 
     return this;
-  }
-
-  getOperationHandler<
-    T extends Operation<K, I, O>,
-    K extends string = KeyOfOperation<T>,
-    I = InputOfOperation<T>,
-    O = OutputOfOperation<T>
-  >(operation: T): OperationHandler<T, K, I, O> {
-    const operationHandler = this.operationHandlers.get(operation.key) as
-      | OperationHandler<T, K, I, O>
-      | undefined;
-
-    if (!operationHandler) {
-      throw new OperationHandlerMissingError(operation.key);
-    }
-
-    return operationHandler;
-  }
-
-  getTask<
-    T extends Operation<K, I, O>,
-    K extends string = KeyOfOperation<T>,
-    I = InputOfOperation<T>,
-    O = OutputOfOperation<T>
-  >(operation: T): Task<O> {
-    const operationHandler = this.getOperationHandler<T, K, I, O>(operation);
-
-    return useTask((scope) => {
-      return operationHandler.handle(operation, this, scope);
-    });
-  }
-
-  execute<
-    T extends Operation<K, I, O>,
-    K extends string = KeyOfOperation<T>,
-    I = InputOfOperation<T>,
-    O = OutputOfOperation<T>
-  >(operation: T, options: TaskOptions = {}): Promise<O> {
-    return this.getTask<T, K, I, O>(operation).run(options);
   }
 }

--- a/src/corePlugin.ts
+++ b/src/corePlugin.ts
@@ -1,0 +1,10 @@
+import { Metaplex } from './Metaplex';
+import { coreProgramsPlugin } from '@/drivers';
+import { nftPlugin } from '@/modules';
+
+export const corePlugin = () => ({
+  install(metaplex: Metaplex) {
+    metaplex.use(coreProgramsPlugin());
+    metaplex.use(nftPlugin());
+  },
+});

--- a/src/drivers/identity/GuestIdentityDriver.ts
+++ b/src/drivers/identity/GuestIdentityDriver.ts
@@ -6,7 +6,7 @@ import { OperationUnauthorizedForGuestsError } from '@/errors';
 
 export const guestIdentity = (): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setIdentity(new GuestIdentityDriver(metaplex));
+    metaplex.setIdentityDriver(new GuestIdentityDriver(metaplex));
   },
 });
 

--- a/src/drivers/identity/KeypairIdentityDriver.ts
+++ b/src/drivers/identity/KeypairIdentityDriver.ts
@@ -7,7 +7,7 @@ import { KeypairSigner } from '@/shared';
 
 export const keypairIdentity = (keypair: Keypair): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setIdentity(new KeypairIdentityDriver(metaplex, keypair));
+    metaplex.setIdentityDriver(new KeypairIdentityDriver(metaplex, keypair));
   },
 });
 

--- a/src/drivers/identity/WalletAdapterIdentityDriver.ts
+++ b/src/drivers/identity/WalletAdapterIdentityDriver.ts
@@ -20,7 +20,7 @@ type WalletAdapter = BaseWalletAdapter &
 
 export const walletAdapterIdentity = (walletAdapter: WalletAdapter): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setIdentity(new WalletAdapterIdentityDriver(metaplex, walletAdapter));
+    metaplex.setIdentityDriver(new WalletAdapterIdentityDriver(metaplex, walletAdapter));
   },
 });
 
@@ -30,7 +30,7 @@ export const walletOrGuestIdentity = (walletAdapter?: WalletAdapter | null): Met
       ? new WalletAdapterIdentityDriver(metaplex, walletAdapter)
       : new GuestIdentityDriver(metaplex);
 
-    metaplex.setIdentity(identity);
+    metaplex.setIdentityDriver(identity);
   },
 });
 

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -1,6 +1,7 @@
 export * from './Driver';
 export * from './filesystem';
 export * from './identity';
+export * from './operations';
 export * from './programs';
 export * from './rpc';
 export * from './storage';

--- a/src/drivers/operations/MapOperationDriver.ts
+++ b/src/drivers/operations/MapOperationDriver.ts
@@ -1,0 +1,73 @@
+import { Task, TaskOptions, useTask } from '@/shared';
+import { OperationHandlerMissingError } from '@/errors';
+import { OperationDriver } from './OperationDriver';
+import {
+  OperationConstructor,
+  Operation,
+  KeyOfOperation,
+  InputOfOperation,
+  OutputOfOperation,
+  OperationHandler,
+} from './Operation';
+
+export class MapOperationDriver extends OperationDriver {
+  /**
+   * Maps the name of an operation with its operation handler.
+   * Whilst the types on the Map are relatively loose, we ensure
+   * operations match with their handlers when registering them.
+   */
+  protected operationHandlers: Map<string, OperationHandler<any, any, any, any>> = new Map();
+
+  register<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(
+    operationConstructor: OperationConstructor<T, K, I, O>,
+    operationHandler: OperationHandler<T, K, I, O>
+  ) {
+    this.operationHandlers.set(operationConstructor.key, operationHandler);
+
+    return this;
+  }
+
+  get<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T): OperationHandler<T, K, I, O> {
+    const operationHandler = this.operationHandlers.get(operation.key) as
+      | OperationHandler<T, K, I, O>
+      | undefined;
+
+    if (!operationHandler) {
+      throw new OperationHandlerMissingError(operation.key);
+    }
+
+    return operationHandler;
+  }
+
+  getTask<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T): Task<O> {
+    const operationHandler = this.get<T, K, I, O>(operation);
+
+    return useTask((scope) => {
+      return operationHandler.handle(operation, this.metaplex, scope);
+    });
+  }
+
+  execute<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T, options: TaskOptions = {}): Promise<O> {
+    return this.getTask<T, K, I, O>(operation).run(options);
+  }
+}

--- a/src/drivers/operations/Operation.ts
+++ b/src/drivers/operations/Operation.ts
@@ -1,5 +1,5 @@
-import { Metaplex } from '..';
-import { DisposableScope } from './useDisposable';
+import { Metaplex } from '../..';
+import { DisposableScope } from '@/shared';
 
 export type KeyOfOperation<T> = T extends Operation<infer N, unknown, unknown> ? N : never;
 export type InputOfOperation<T> = T extends Operation<string, infer I, unknown> ? I : never;

--- a/src/drivers/operations/OperationDriver.ts
+++ b/src/drivers/operations/OperationDriver.ts
@@ -1,0 +1,47 @@
+import { Task, TaskOptions } from '@/shared';
+import { Driver } from '../Driver';
+import {
+  OperationConstructor,
+  Operation,
+  KeyOfOperation,
+  InputOfOperation,
+  OutputOfOperation,
+  OperationHandler,
+} from './Operation';
+
+export abstract class OperationDriver extends Driver {
+  public abstract register<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(
+    operationConstructor: OperationConstructor<T, K, I, O>,
+    operationHandler: OperationHandler<T, K, I, O>
+  ): void;
+
+  public abstract get<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T): OperationHandler<T, K, I, O>;
+
+  // Have to use "T | Operation<K, I, O>" for the type
+  // of the subclasses to be inferred correctly.
+  public abstract getTask<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T | Operation<K, I, O>): Task<O>;
+
+  // Have to use "T | Operation<K, I, O>" for the type
+  // of the subclasses to be inferred correctly.
+  public abstract execute<
+    T extends Operation<K, I, O>,
+    K extends string = KeyOfOperation<T>,
+    I = InputOfOperation<T>,
+    O = OutputOfOperation<T>
+  >(operation: T | Operation<K, I, O>, options?: TaskOptions): Promise<O>;
+}

--- a/src/drivers/operations/index.ts
+++ b/src/drivers/operations/index.ts
@@ -1,0 +1,3 @@
+export * from './MapOperationDriver';
+export * from './OperationDriver';
+export * from './Operation';

--- a/src/drivers/programs/coreProgramsPlugin.ts
+++ b/src/drivers/programs/coreProgramsPlugin.ts
@@ -8,7 +8,7 @@ import { Metaplex } from '@/Metaplex';
 import { TokenMetadataGpaBuilder, TokenProgramGpaBuilder } from '@/programs';
 import { ErrorWithLogs } from './Program';
 
-export const coreProgramsPlugin = {
+export const coreProgramsPlugin = () => ({
   install(metaplex: Metaplex) {
     // System Program.
     metaplex.programs().register({
@@ -33,4 +33,4 @@ export const coreProgramsPlugin = {
         new TokenMetadataGpaBuilder(metaplex, TOKEN_METADATA_PROGRAM_ID),
     });
   },
-};
+});

--- a/src/drivers/storage/AwsStorageDriver.ts
+++ b/src/drivers/storage/AwsStorageDriver.ts
@@ -7,7 +7,7 @@ import { SolAmount } from '@/shared';
 
 export const awsStorage = (client: S3Client, bucketName: string): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setStorage(new AwsStorageDriver(metaplex, client, bucketName));
+    metaplex.setStorageDriver(new AwsStorageDriver(metaplex, client, bucketName));
   },
 });
 

--- a/src/drivers/storage/BundlrStorageDriver.ts
+++ b/src/drivers/storage/BundlrStorageDriver.ts
@@ -24,7 +24,7 @@ export interface BundlrOptions {
 
 export const bundlrStorage = (options: BundlrOptions = {}): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setStorage(new BundlrStorageDriver(metaplex, options));
+    metaplex.setStorageDriver(new BundlrStorageDriver(metaplex, options));
     metaplex
       .operations()
       .register(planUploadMetadataOperation, planUploadMetadataUsingBundlrOperationHandler);

--- a/src/drivers/storage/BundlrStorageDriver.ts
+++ b/src/drivers/storage/BundlrStorageDriver.ts
@@ -25,7 +25,9 @@ export interface BundlrOptions {
 export const bundlrStorage = (options: BundlrOptions = {}): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
     metaplex.setStorage(new BundlrStorageDriver(metaplex, options));
-    metaplex.register(planUploadMetadataOperation, planUploadMetadataUsingBundlrOperationHandler);
+    metaplex
+      .operations()
+      .register(planUploadMetadataOperation, planUploadMetadataUsingBundlrOperationHandler);
   },
 });
 

--- a/src/drivers/storage/MockStorageDriver.ts
+++ b/src/drivers/storage/MockStorageDriver.ts
@@ -16,7 +16,7 @@ export interface MockStorageOptions {
 
 export const mockStorage = (options?: MockStorageOptions): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.setStorage(new MockStorageDriver(metaplex, options));
+    metaplex.setStorageDriver(new MockStorageDriver(metaplex, options));
   },
 });
 

--- a/src/drivers/storage/planUploadMetadataUsingBundlrOperationHandler.ts
+++ b/src/drivers/storage/planUploadMetadataUsingBundlrOperationHandler.ts
@@ -6,7 +6,8 @@ import {
   replaceAssetsWithUris,
   UploadMetadataOutput,
 } from '@/modules/nfts';
-import { Plan, OperationHandler, DisposableScope } from '@/shared';
+import { Plan, DisposableScope } from '@/shared';
+import { OperationHandler } from '../operations';
 import { MetaplexFile } from '../filesystem';
 import { BundlrStorageDriver } from './BundlrStorageDriver';
 

--- a/src/modules/nfts/NftClient.ts
+++ b/src/modules/nfts/NftClient.ts
@@ -27,36 +27,38 @@ import {
 
 export class NftClient extends ModuleClient {
   findNftByMint(mint: PublicKey): Promise<Nft> {
-    return this.metaplex.execute(findNftByMintOperation(mint));
+    return this.metaplex.operations().execute(findNftByMintOperation(mint));
   }
 
   findNftsByMintList(mints: PublicKey[]): Promise<(Nft | null)[]> {
-    return this.metaplex.execute(findNftsByMintListOperation(mints));
+    return this.metaplex.operations().execute(findNftsByMintListOperation(mints));
   }
 
   findNftsByOwner(owner: PublicKey): Promise<Nft[]> {
-    return this.metaplex.execute(findNftsByOwnerOperation(owner));
+    return this.metaplex.operations().execute(findNftsByOwnerOperation(owner));
   }
 
   findNftsByCreator(creator: PublicKey, position: number = 1): Promise<Nft[]> {
-    return this.metaplex.execute(findNftsByCreatorOperation({ creator, position }));
+    return this.metaplex.operations().execute(findNftsByCreatorOperation({ creator, position }));
   }
 
   findNftsByCandyMachine(candyMachine: PublicKey, version?: 1 | 2): Promise<Nft[]> {
-    return this.metaplex.execute(findNftsByCandyMachineOperation({ candyMachine, version }));
+    return this.metaplex
+      .operations()
+      .execute(findNftsByCandyMachineOperation({ candyMachine, version }));
   }
 
   uploadMetadata(input: UploadMetadataInput): Promise<UploadMetadataOutput> {
-    return this.metaplex.execute(uploadMetadataOperation(input));
+    return this.metaplex.operations().execute(uploadMetadataOperation(input));
   }
 
   planUploadMetadata(input: UploadMetadataInput): Promise<Plan<undefined, UploadMetadataOutput>> {
-    return this.metaplex.execute(planUploadMetadataOperation(input));
+    return this.metaplex.operations().execute(planUploadMetadataOperation(input));
   }
 
   async createNft(input: CreateNftInput): Promise<{ nft: Nft } & CreateNftOutput> {
     const operation = createNftOperation(input);
-    const createNftOutput = await this.metaplex.execute(operation);
+    const createNftOutput = await this.metaplex.operations().execute(operation);
     const nft = await this.findNftByMint(createNftOutput.mint.publicKey);
 
     return { ...createNftOutput, nft };
@@ -67,7 +69,7 @@ export class NftClient extends ModuleClient {
     input: Omit<UpdateNftInput, 'nft'>
   ): Promise<{ nft: Nft } & UpdateNftOutput> {
     const operation = updateNftOperation({ ...input, nft });
-    const updateNftOutput = await this.metaplex.execute(operation);
+    const updateNftOutput = await this.metaplex.operations().execute(operation);
     const updatedNft = await this.findNftByMint(nft.mint);
 
     return { ...updateNftOutput, nft: updatedNft };
@@ -78,7 +80,7 @@ export class NftClient extends ModuleClient {
     input: Omit<PrintNewEditionSharedInput, 'originalMint'> & PrintNewEditionViaInput = {}
   ): Promise<{ nft: Nft } & PrintNewEditionOutput> {
     const operation = printNewEditionOperation({ originalMint, ...input });
-    const printNewEditionOutput = await this.metaplex.execute(operation);
+    const printNewEditionOutput = await this.metaplex.operations().execute(operation);
     const nft = await this.findNftByMint(printNewEditionOutput.mint.publicKey);
 
     return { ...printNewEditionOutput, nft };

--- a/src/modules/nfts/index.ts
+++ b/src/modules/nfts/index.ts
@@ -12,19 +12,28 @@ import * as h from './operationHandlers';
 
 export const nftPlugin = (): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
-    metaplex.register(o.createNftOperation, h.createNftOperationHandler);
-    metaplex.register(o.findNftByMintOperation, h.findNftByMintOnChainOperationHandler);
-    metaplex.register(
-      o.findNftsByCandyMachineOperation,
-      h.findNftsByCandyMachineOnChainOperationHandler
-    );
-    metaplex.register(o.findNftsByCreatorOperation, h.findNftsByCreatorOnChainOperationHandler);
-    metaplex.register(o.findNftsByMintListOperation, h.findNftsByMintListOnChainOperationHandler);
-    metaplex.register(o.findNftsByOwnerOperation, h.findNftsByOwnerOnChainOperationHandler);
-    metaplex.register(o.printNewEditionOperation, h.printNewEditionOperationHandler);
-    metaplex.register(o.planUploadMetadataOperation, h.planUploadMetadataOperationHandler);
-    metaplex.register(o.updateNftOperation, h.updateNftOperationHandler);
-    metaplex.register(o.uploadMetadataOperation, h.uploadMetadataOperationHandler);
+    metaplex.operations().register(o.createNftOperation, h.createNftOperationHandler);
+    metaplex
+      .operations()
+      .register(o.findNftByMintOperation, h.findNftByMintOnChainOperationHandler);
+    metaplex
+      .operations()
+      .register(o.findNftsByCandyMachineOperation, h.findNftsByCandyMachineOnChainOperationHandler);
+    metaplex
+      .operations()
+      .register(o.findNftsByCreatorOperation, h.findNftsByCreatorOnChainOperationHandler);
+    metaplex
+      .operations()
+      .register(o.findNftsByMintListOperation, h.findNftsByMintListOnChainOperationHandler);
+    metaplex
+      .operations()
+      .register(o.findNftsByOwnerOperation, h.findNftsByOwnerOnChainOperationHandler);
+    metaplex.operations().register(o.printNewEditionOperation, h.printNewEditionOperationHandler);
+    metaplex
+      .operations()
+      .register(o.planUploadMetadataOperation, h.planUploadMetadataOperationHandler);
+    metaplex.operations().register(o.updateNftOperation, h.updateNftOperationHandler);
+    metaplex.operations().register(o.uploadMetadataOperation, h.uploadMetadataOperationHandler);
 
     metaplex.nfts = function () {
       return new NftClient(this);

--- a/src/modules/nfts/index.ts
+++ b/src/modules/nfts/index.ts
@@ -3,46 +3,4 @@ export * from './operationHandlers';
 export * from './operations';
 export * from './transactionBuilders';
 export * from './NftClient';
-
-import { Metaplex } from '@/Metaplex';
-import { MetaplexPlugin } from '@/MetaplexPlugin';
-import { NftClient } from './NftClient';
-import * as o from './operations';
-import * as h from './operationHandlers';
-
-export const nftPlugin = (): MetaplexPlugin => ({
-  install(metaplex: Metaplex) {
-    metaplex.operations().register(o.createNftOperation, h.createNftOperationHandler);
-    metaplex
-      .operations()
-      .register(o.findNftByMintOperation, h.findNftByMintOnChainOperationHandler);
-    metaplex
-      .operations()
-      .register(o.findNftsByCandyMachineOperation, h.findNftsByCandyMachineOnChainOperationHandler);
-    metaplex
-      .operations()
-      .register(o.findNftsByCreatorOperation, h.findNftsByCreatorOnChainOperationHandler);
-    metaplex
-      .operations()
-      .register(o.findNftsByMintListOperation, h.findNftsByMintListOnChainOperationHandler);
-    metaplex
-      .operations()
-      .register(o.findNftsByOwnerOperation, h.findNftsByOwnerOnChainOperationHandler);
-    metaplex.operations().register(o.printNewEditionOperation, h.printNewEditionOperationHandler);
-    metaplex
-      .operations()
-      .register(o.planUploadMetadataOperation, h.planUploadMetadataOperationHandler);
-    metaplex.operations().register(o.updateNftOperation, h.updateNftOperationHandler);
-    metaplex.operations().register(o.uploadMetadataOperation, h.uploadMetadataOperationHandler);
-
-    metaplex.nfts = function () {
-      return new NftClient(this);
-    };
-  },
-});
-
-declare module '../../Metaplex' {
-  interface Metaplex {
-    nfts(): NftClient;
-  }
-}
+export * from './plugin';

--- a/src/modules/nfts/operationHandlers/createNftOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/createNftOperationHandler.ts
@@ -6,7 +6,7 @@ import { CreateNftInput, CreateNftOperation } from '../operations';
 import { JsonMetadata } from '../models/JsonMetadata';
 import { createNftBuilder } from '../transactionBuilders';
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 
 export const createNftOperationHandler: OperationHandler<CreateNftOperation> = {
   handle: async (operation: CreateNftOperation, metaplex: Metaplex) => {

--- a/src/modules/nfts/operationHandlers/findNftByMintOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftByMintOnChainOperationHandler.ts
@@ -1,5 +1,5 @@
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { Nft } from '../models';
 import { FindNftByMintOperation } from '../operations/findNftByMintOperation';
 import { MetadataAccount, OriginalOrPrintEditionAccount } from '@/programs';

--- a/src/modules/nfts/operationHandlers/findNftsByCandyMachineOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByCandyMachineOnChainOperationHandler.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { Nft } from '../models';
 import { FindNftsByCandyMachineOperation, findNftsByCreatorOperation } from '../operations';
 
@@ -21,7 +21,7 @@ export const findNftsByCandyMachineOnChainOperationHandler: OperationHandler<Fin
         );
       }
 
-      return metaplex.execute(
+      return metaplex.operations().execute(
         findNftsByCreatorOperation({
           creator: firstCreator,
           position: 1,

--- a/src/modules/nfts/operationHandlers/findNftsByCreatorOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByCreatorOnChainOperationHandler.ts
@@ -1,6 +1,6 @@
 import { Metaplex } from '@/Metaplex';
 import { TokenMetadataProgram } from '@/programs';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { Nft } from '../models';
 import { findNftsByMintListOperation, FindNftsByCreatorOperation } from '../operations';
 
@@ -14,7 +14,7 @@ export const findNftsByCreatorOnChainOperationHandler: OperationHandler<FindNfts
         .whereCreator(position, creator)
         .getDataAsPublicKeys();
 
-      const nfts = await metaplex.execute(findNftsByMintListOperation(mints));
+      const nfts = await metaplex.operations().execute(findNftsByMintListOperation(mints));
 
       return nfts.filter((nft): nft is Nft => nft !== null);
     },

--- a/src/modules/nfts/operationHandlers/findNftsByMintListOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByMintListOnChainOperationHandler.ts
@@ -1,6 +1,7 @@
 import { Metaplex } from '@/Metaplex';
 import { MetadataAccount } from '@/programs';
-import { GmaBuilder, OperationHandler } from '@/shared';
+import { GmaBuilder } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { zipMap } from '@/utils';
 import { Nft } from '../models';
 import { FindNftsByMintListOperation } from '../operations/findNftsByMintListOperation';

--- a/src/modules/nfts/operationHandlers/findNftsByOwnerOnChainOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/findNftsByOwnerOnChainOperationHandler.ts
@@ -1,6 +1,6 @@
 import { Metaplex } from '@/Metaplex';
 import { TokenProgram } from '@/programs';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { Nft } from '../models';
 import { findNftsByMintListOperation, FindNftsByOwnerOperation } from '../operations';
 
@@ -14,7 +14,7 @@ export const findNftsByOwnerOnChainOperationHandler: OperationHandler<FindNftsBy
       .whereAmount(1)
       .getDataAsPublicKeys();
 
-    const nfts = await metaplex.execute(findNftsByMintListOperation(mints));
+    const nfts = await metaplex.operations().execute(findNftsByMintListOperation(mints));
 
     return nfts.filter((nft): nft is Nft => nft !== null);
   },

--- a/src/modules/nfts/operationHandlers/planUploadMetadataOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/planUploadMetadataOperationHandler.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import { Metaplex } from '@/Metaplex';
-import { MetaplexFile } from '@/drivers';
-import { Plan, OperationHandler } from '@/shared';
+import { MetaplexFile, OperationHandler } from '@/drivers';
+import { Plan } from '@/shared';
 import { walk } from '@/utils';
 import { JsonMetadata } from '../models';
 import {

--- a/src/modules/nfts/operationHandlers/printNewEditionOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/printNewEditionOperationHandler.ts
@@ -10,7 +10,8 @@ import {
 import { PrintNewEditionOperation } from '../operations';
 import { printNewEditionBuilder } from '../transactionBuilders';
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler, TransactionBuilder } from '@/shared';
+import { OperationHandler } from '@/drivers';
+import { TransactionBuilder } from '@/shared';
 import { AccountNotFoundError } from '@/errors';
 
 export const printNewEditionOperationHandler: OperationHandler<PrintNewEditionOperation> = {

--- a/src/modules/nfts/operationHandlers/updateNftOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/updateNftOperationHandler.ts
@@ -1,6 +1,6 @@
 import { DataV2 } from '@metaplex-foundation/mpl-token-metadata';
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import { MetadataAccount } from '@/programs';
 import { UpdateNftInput, UpdateNftOperation, UpdateNftOutput } from '../operations';
 import { updateNftBuilder } from '../transactionBuilders';

--- a/src/modules/nfts/operationHandlers/uploadMetadataOperationHandler.ts
+++ b/src/modules/nfts/operationHandlers/uploadMetadataOperationHandler.ts
@@ -1,5 +1,5 @@
 import { Metaplex } from '@/Metaplex';
-import { OperationHandler } from '@/shared';
+import { OperationHandler } from '@/drivers';
 import {
   planUploadMetadataOperation,
   UploadMetadataOperation,
@@ -11,7 +11,7 @@ export const uploadMetadataOperationHandler: OperationHandler<UploadMetadataOper
     operation: UploadMetadataOperation,
     metaplex: Metaplex
   ): Promise<UploadMetadataOutput> => {
-    const plan = await metaplex.execute(planUploadMetadataOperation(operation.input));
+    const plan = await metaplex.operations().execute(planUploadMetadataOperation(operation.input));
 
     return plan.execute();
   },

--- a/src/modules/nfts/operations/createNftOperation.ts
+++ b/src/modules/nfts/operations/createNftOperation.ts
@@ -1,7 +1,8 @@
 import { ConfirmOptions, PublicKey } from '@solana/web3.js';
 import { bignum } from '@metaplex-foundation/beet';
 import { Creator, Collection, Uses } from '@metaplex-foundation/mpl-token-metadata';
-import { useOperation, Signer, Operation } from '@/shared';
+import { useOperation, Operation } from '@/drivers';
+import { Signer } from '@/shared';
 
 export const createNftOperation = useOperation<CreateNftOperation>('CreateNftOperation');
 

--- a/src/modules/nfts/operations/findNftByMintOperation.ts
+++ b/src/modules/nfts/operations/findNftByMintOperation.ts
@@ -1,4 +1,4 @@
-import { Operation, useOperation } from '@/shared';
+import { Operation, useOperation } from '@/drivers';
 import { PublicKey } from '@solana/web3.js';
 import { Nft } from '../models';
 

--- a/src/modules/nfts/operations/findNftsByCandyMachineOperation.ts
+++ b/src/modules/nfts/operations/findNftsByCandyMachineOperation.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Operation, useOperation } from '@/shared';
+import { Operation, useOperation } from '@/drivers';
 import { Nft } from '../models';
 
 export const findNftsByCandyMachineOperation = useOperation<FindNftsByCandyMachineOperation>(

--- a/src/modules/nfts/operations/findNftsByCreatorOperation.ts
+++ b/src/modules/nfts/operations/findNftsByCreatorOperation.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Operation, useOperation } from '@/shared';
+import { Operation, useOperation } from '@/drivers';
 import { Nft } from '../models';
 
 export const findNftsByCreatorOperation = useOperation<FindNftsByCreatorOperation>(

--- a/src/modules/nfts/operations/findNftsByMintListOperation.ts
+++ b/src/modules/nfts/operations/findNftsByMintListOperation.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Operation, useOperation } from '@/shared';
+import { Operation, useOperation } from '@/drivers';
 import { Nft } from '../models';
 
 export const findNftsByMintListOperation = useOperation<FindNftsByMintListOperation>(

--- a/src/modules/nfts/operations/findNftsByOwnerOperation.ts
+++ b/src/modules/nfts/operations/findNftsByOwnerOperation.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Operation, useOperation } from '@/shared';
+import { Operation, useOperation } from '@/drivers';
 import { Nft } from '../models';
 
 export const findNftsByOwnerOperation = useOperation<FindNftsByOwnerOperation>(

--- a/src/modules/nfts/operations/planUploadMetadataOperation.ts
+++ b/src/modules/nfts/operations/planUploadMetadataOperation.ts
@@ -1,4 +1,5 @@
-import { useOperation, Plan, Operation } from '@/shared';
+import { useOperation, Operation } from '@/drivers';
+import { Plan } from '@/shared';
 import { UploadMetadataInput, UploadMetadataOutput } from './uploadMetadataOperation';
 
 export const planUploadMetadataOperation = useOperation<PlanUploadMetadataOperation>(

--- a/src/modules/nfts/operations/printNewEditionOperation.ts
+++ b/src/modules/nfts/operations/printNewEditionOperation.ts
@@ -1,5 +1,6 @@
 import { ConfirmOptions, PublicKey } from '@solana/web3.js';
-import { useOperation, Signer, Operation } from '@/shared';
+import { useOperation, Operation } from '@/drivers';
+import { Signer } from '@/shared';
 
 export const printNewEditionOperation = useOperation<PrintNewEditionOperation>(
   'PrintNewEditionOperation'

--- a/src/modules/nfts/operations/updateNftOperation.ts
+++ b/src/modules/nfts/operations/updateNftOperation.ts
@@ -1,6 +1,7 @@
 import { ConfirmOptions, PublicKey } from '@solana/web3.js';
 import { Collection, Creator, Uses } from '@metaplex-foundation/mpl-token-metadata';
-import { useOperation, Signer, Operation } from '@/shared';
+import { useOperation, Operation } from '@/drivers';
+import { Signer } from '@/shared';
 import { Nft } from '../models';
 
 export const updateNftOperation = useOperation<UpdateNftOperation>('UpdateNftOperation');

--- a/src/modules/nfts/operations/uploadMetadataOperation.ts
+++ b/src/modules/nfts/operations/uploadMetadataOperation.ts
@@ -1,5 +1,4 @@
-import { MetaplexFile } from '@/drivers';
-import { Operation, useOperation } from '@/shared';
+import { MetaplexFile, Operation, useOperation } from '@/drivers';
 import { JsonMetadata } from '../models';
 
 export const uploadMetadataOperation =

--- a/src/modules/nfts/plugin.ts
+++ b/src/modules/nfts/plugin.ts
@@ -1,0 +1,31 @@
+import { Metaplex } from '@/Metaplex';
+import { MetaplexPlugin } from '@/MetaplexPlugin';
+import { NftClient } from './NftClient';
+import * as o from './operations';
+import * as h from './operationHandlers';
+
+export const nftPlugin = (): MetaplexPlugin => ({
+  install(metaplex: Metaplex) {
+    const op = metaplex.operations();
+    op.register(o.createNftOperation, h.createNftOperationHandler);
+    op.register(o.findNftByMintOperation, h.findNftByMintOnChainOperationHandler);
+    op.register(o.findNftsByCandyMachineOperation, h.findNftsByCandyMachineOnChainOperationHandler);
+    op.register(o.findNftsByCreatorOperation, h.findNftsByCreatorOnChainOperationHandler);
+    op.register(o.findNftsByMintListOperation, h.findNftsByMintListOnChainOperationHandler);
+    op.register(o.findNftsByOwnerOperation, h.findNftsByOwnerOnChainOperationHandler);
+    op.register(o.printNewEditionOperation, h.printNewEditionOperationHandler);
+    op.register(o.planUploadMetadataOperation, h.planUploadMetadataOperationHandler);
+    op.register(o.updateNftOperation, h.updateNftOperationHandler);
+    op.register(o.uploadMetadataOperation, h.uploadMetadataOperationHandler);
+
+    metaplex.nfts = function () {
+      return new NftClient(this);
+    };
+  },
+});
+
+declare module '../../Metaplex' {
+  interface Metaplex {
+    nfts(): NftClient;
+  }
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -12,4 +12,3 @@ export * from './SolAmount';
 export * from './TransactionBuilder';
 export * from './useDisposable';
 export * from './useTask';
-export * from './useOperation';

--- a/test/drivers/rpc/Web3RpcDriver.test.ts
+++ b/test/drivers/rpc/Web3RpcDriver.test.ts
@@ -8,7 +8,7 @@ const init = async () => {
   const mx = await metaplex();
 
   // Ensure we are testing the Web3RpcDriver.
-  mx.setRpc(new Web3RpcDriver(mx));
+  mx.setRpcDriver(new Web3RpcDriver(mx));
 
   return { mx, rpc: mx.rpc() };
 };


### PR DESCRIPTION
This PR pushes all the logic of registering and executing operations and their handlers into a dedicated driver. That way, the Metaplex class is freed from this burden and acts as a simple hub for drivers.

The PR also:
- Extracts the plugin of the NFT module into its own `plugin.ts` file (before it was difficult to discover).
- Creates a new `corePlugin` that registers all the plugins that are registered by default.
- Renames all driver setters so they explicitly say `Driver` at the end. E.g. `setPrograms` becomes `setProgramDriver`. The former was a bit confusing as to what it was doing.