### PR TITLE
chore: small candy machine changes as requested

### DIFF
--- a/src/errors/CandyMachineError.ts
+++ b/src/errors/CandyMachineError.ts
@@ -5,10 +5,10 @@ export class CandyMachineError extends MetaplexError {
   constructor(input: MetaplexErrorInputWithoutSource) {
     super({
       ...input,
-      key: `plugin.candy machine.${input.key}`,
-      title: `NFT > ${input.title}`,
+      key: `plugin.candy_machine.${input.key}`,
+      title: `Candy Machine > ${input.title}`,
       source: 'plugin',
-      sourceDetails: 'NFT',
+      sourceDetails: 'Candy Machine',
     });
   }
 }

--- a/src/errors/CandyMachineError.ts
+++ b/src/errors/CandyMachineError.ts
@@ -1,0 +1,46 @@
+import { PublicKey } from '@solana/web3.js';
+import { MetaplexError, MetaplexErrorInputWithoutSource } from './MetaplexError';
+
+export class CandyMachineError extends MetaplexError {
+  constructor(input: MetaplexErrorInputWithoutSource) {
+    super({
+      ...input,
+      key: `plugin.candy machine.${input.key}`,
+      title: `NFT > ${input.title}`,
+      source: 'plugin',
+      sourceDetails: 'NFT',
+    });
+  }
+}
+
+export class CandyMachineNotFoundError extends CandyMachineError {
+  constructor(candyMachineAddress: PublicKey, cause?: Error) {
+    super({
+      cause,
+      key: 'candy_machine_not_found',
+      title: 'CandyMachine Not Found',
+      problem:
+        'No Metadata account could be found for the provided candy machine address: ' +
+        `[${candyMachineAddress.toBase58()}].`,
+      solution:
+        'Ensure the provided candy machine address is valid and that an associated ' +
+        'Metadata account exists on the blockchain.',
+    });
+  }
+}
+
+export class CreatedCandyMachineNotFoundError extends CandyMachineError {
+  constructor(candyMachineAddress: PublicKey, cause?: Error) {
+    super({
+      cause,
+      key: 'created_candy_machine_not_found',
+      title: 'Created CandyMachine Not Found',
+      problem:
+        'No Metadata account could be found for the candy machine that the client just created: ' +
+        `[${candyMachineAddress.toBase58()}].`,
+      solution:
+        'Ensure that the candy machine could be created properly and without errors.' +
+        'If the problem persists please file an issue.',
+    });
+  }
+}

--- a/src/errors/SdkError.ts
+++ b/src/errors/SdkError.ts
@@ -196,3 +196,15 @@ export class NotYetImplementedError extends SdkError {
     });
   }
 }
+
+export class UnreachableCaseError extends SdkError {
+  constructor(value: never, cause?: Error) {
+    super({
+      cause,
+      key: 'unreachable_case',
+      title: 'A Case in a Switch or If Statement Is Unreachable.',
+      problem: 'The developer is not handling that case yet.',
+      solution: 'Check your inputs or file an issue to have all cases handled.',
+    });
+  }
+}

--- a/src/errors/SdkError.ts
+++ b/src/errors/SdkError.ts
@@ -202,9 +202,10 @@ export class UnreachableCaseError extends SdkError {
     super({
       cause,
       key: 'unreachable_case',
-      title: 'A Case in a Switch or If Statement Is Unreachable.',
-      problem: 'The developer is not handling that case yet.',
-      solution: 'Check your inputs or file an issue to have all cases handled.',
+      title: `The Case '${value}' in a Switch or If Statement went Unhandled.`,
+      problem:
+        'The developer is not handling that case yet or is missing a `break` or `return` statement.',
+      solution: 'Check your inputs or file an issue to have all cases handled properly.',
     });
   }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,5 @@
 export * from './BundlrError';
+export * from './CandyMachineError';
 export * from './MetaplexError';
 export * from './NftError';
 export * from './ProgramError';

--- a/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -1,5 +1,6 @@
 import { ConfirmOptions, Keypair, PublicKey } from '@solana/web3.js';
 import { ModuleClient, Signer, convertToPublickKey } from '@/types';
+import { CreatedCandyMachineNotFoundError } from '@/errors';
 import { CandyMachineConfigWithoutStorage, candyMachineDataFromConfig } from './config';
 import {
   CreateCandyMachineInput,
@@ -16,7 +17,7 @@ export type CandyMachineInitFromConfigOpts = {
 };
 
 export class CandyMachineClient extends ModuleClient {
-  findCandyMachineByAddress(address: PublicKey): Promise<CandyMachine> {
+  findCandyMachineByAddress(address: PublicKey): Promise<CandyMachine | null> {
     const operation = findCandyMachineByAdddressOperation(address);
     return this.metaplex.operations().execute(operation);
   }
@@ -27,8 +28,10 @@ export class CandyMachineClient extends ModuleClient {
     const operation = createCandyMachineOperation(input);
     const output = await this.metaplex.operations().execute(operation);
 
-    // TODO(thlorenz): gracefully handle if not found.
     const candyMachine = await this.findCandyMachineByAddress(output.candyMachineSigner.publicKey);
+    if (candyMachine === null) {
+      throw new CreatedCandyMachineNotFoundError(output.candyMachineSigner.publicKey);
+    }
 
     return { candyMachine, ...output };
   }

--- a/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -1,5 +1,5 @@
 import { ConfirmOptions, Keypair, PublicKey } from '@solana/web3.js';
-import { ModuleClient, Signer, tryConvertToPublickKey } from '@/types';
+import { ModuleClient, Signer, convertToPublickKey } from '@/types';
 import { CandyMachineConfigWithoutStorage, candyMachineDataFromConfig } from './config';
 import {
   CreateCandyMachineInput,
@@ -39,7 +39,7 @@ export class CandyMachineClient extends ModuleClient {
   ): Promise<CreateCandyMachineOutput & { candyMachine: CandyMachine }> {
     const { candyMachineSigner = Keypair.generate() } = opts;
     const candyMachineData = candyMachineDataFromConfig(config, candyMachineSigner.publicKey);
-    const walletAddress = tryConvertToPublickKey(config.solTreasuryAccount);
+    const walletAddress = convertToPublickKey(config.solTreasuryAccount);
 
     return this.createCandyMachine({
       candyMachineData,

--- a/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -42,10 +42,10 @@ export class CandyMachineClient extends ModuleClient {
     const walletAddress = convertToPublickKey(config.solTreasuryAccount);
 
     return this.createCandyMachine({
-      candyMachineData,
       candyMachineSigner,
       walletAddress,
       authorityAddress: opts.authorityAddress,
+      ...candyMachineData,
     });
   }
 }

--- a/src/plugins/candyMachineModule/config/EndSettings.ts
+++ b/src/plugins/candyMachineModule/config/EndSettings.ts
@@ -1,6 +1,6 @@
 import { EndSettings, EndSettingType } from '@metaplex-foundation/mpl-candy-machine';
 import BN from 'bn.js';
-import { tryConvertToMillisecondsSinceEpoch } from '@/types';
+import { convertToMillisecondsSinceEpoch } from '@/types';
 
 export const ENDSETTING_DATE = 'date';
 export const ENDSETTING_AMOUNT = 'amount';
@@ -34,7 +34,7 @@ export function endSettingsFromConfig(config?: EndSettingsConfig): EndSettings |
 
   const value =
     config.endSettingType === ENDSETTING_DATE
-      ? tryConvertToMillisecondsSinceEpoch(config.value)
+      ? convertToMillisecondsSinceEpoch(config.value)
       : new BN(config.value);
   return {
     endSettingType,

--- a/src/plugins/candyMachineModule/config/Gatekeeper.ts
+++ b/src/plugins/candyMachineModule/config/Gatekeeper.ts
@@ -1,5 +1,5 @@
 import { GatekeeperConfig } from '@metaplex-foundation/mpl-candy-machine';
-import { PublicKeyString, tryConvertToPublickKey } from '@/types';
+import { PublicKeyString, convertToPublickKey } from '@/types';
 
 /**
  * Configures {@link CandyMachineConfig.gatekeeper} settings.
@@ -24,6 +24,6 @@ export function gatekeeperFromConfig(
 
   return {
     ...config,
-    gatekeeperNetwork: tryConvertToPublickKey(config.gatekeeperNetwork),
+    gatekeeperNetwork: convertToPublickKey(config.gatekeeperNetwork),
   };
 }

--- a/src/plugins/candyMachineModule/config/WhitelistMint.ts
+++ b/src/plugins/candyMachineModule/config/WhitelistMint.ts
@@ -1,7 +1,7 @@
 import { WhitelistMintMode, WhitelistMintSettings } from '@metaplex-foundation/mpl-candy-machine';
 import BN from 'bn.js';
 import { PublicKeyString, convertToPublickKey } from '@/types';
-import { UnreachableCaseError } from '@/utils';
+import { UnreachableCaseError } from '@/errors';
 
 export const BURN_EVERY_TIME = 'burnEveryTime';
 export const NEVER_BURN = 'neverBurn';

--- a/src/plugins/candyMachineModule/config/WhitelistMint.ts
+++ b/src/plugins/candyMachineModule/config/WhitelistMint.ts
@@ -1,6 +1,6 @@
 import { WhitelistMintMode, WhitelistMintSettings } from '@metaplex-foundation/mpl-candy-machine';
 import BN from 'bn.js';
-import { PublicKeyString, tryConvertToPublickKey } from '@/types';
+import { PublicKeyString, convertToPublickKey } from '@/types';
 import { UnreachableCaseError } from '@/utils';
 
 export const BURN_EVERY_TIME = 'burnEveryTime';
@@ -50,7 +50,7 @@ export function whiteListMintSettingsFromConfig(
     default:
       throw new UnreachableCaseError(config.mode);
   }
-  const mint = tryConvertToPublickKey(config.mint);
+  const mint = convertToPublickKey(config.mint);
   const discountPrice = new BN(config.discountPrice);
 
   return { ...config, mode, mint, discountPrice };

--- a/src/plugins/candyMachineModule/config/fromConfig.ts
+++ b/src/plugins/candyMachineModule/config/fromConfig.ts
@@ -6,7 +6,7 @@ import {
 } from '@metaplex-foundation/mpl-candy-machine';
 import { PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
-import { tryConvertToMillisecondsSinceEpoch, tryConvertToPublickKey } from '@/types';
+import { convertToMillisecondsSinceEpoch, convertToPublickKey } from '@/types';
 import { CandyMachineConfigWithoutStorage } from './CandyMachineConfig';
 import { creatorsConfigDefault } from './Creators';
 import { endSettingsFromConfig } from './EndSettings';
@@ -28,10 +28,10 @@ export function candyMachineDataFromConfig(
   const configCreators = config.creators ?? creatorsConfigDefault(config.solTreasuryAccount);
   const creators: Creator[] = configCreators.map((creatorConfig) => ({
     ...creatorConfig,
-    address: tryConvertToPublickKey(creatorConfig.address),
+    address: convertToPublickKey(creatorConfig.address),
   }));
 
-  const goLiveDate = tryConvertToMillisecondsSinceEpoch(config.goLiveDate);
+  const goLiveDate = convertToMillisecondsSinceEpoch(config.goLiveDate);
 
   const hiddenSettings = hiddenSettingsFromConfig(config.hiddenSettings) ?? null;
   const endSettings = endSettingsFromConfig(config.endSettings) ?? null;

--- a/src/plugins/candyMachineModule/createCandyMachine.ts
+++ b/src/plugins/candyMachineModule/createCandyMachine.ts
@@ -23,11 +23,7 @@ export type CreateCandyMachineOperation = Operation<
   CreateCandyMachineOutput
 >;
 
-export type CreateCandyMachineInput = {
-  // Data.
-  // TODO(loris): spread data into the input directly.
-  candyMachineData: CandyMachineData;
-
+export type CreateCandyMachineInput = CandyMachineData & {
   // Accounts.
   candyMachineSigner?: Signer;
   payerSigner?: Signer;
@@ -56,23 +52,23 @@ export const createCandyMachineOperationHandler: OperationHandler<CreateCandyMac
     metaplex: Metaplex
   ): Promise<CreateCandyMachineOutput> {
     const {
-      candyMachineData,
       candyMachineSigner = Keypair.generate(),
       payerSigner = metaplex.identity(),
       walletAddress = payerSigner.publicKey,
       authorityAddress = payerSigner.publicKey,
       confirmOptions,
+      ...candyMachineData
     } = operation.input;
 
     const { signature, confirmResponse } = await metaplex.rpc().sendAndConfirmTransaction(
       await createCandyMachineBuilder({
         metaplex,
-        candyMachineData,
         payerSigner,
         candyMachineSigner,
         walletAddress,
         authorityAddress,
         confirmOptions,
+        ...candyMachineData,
       }),
       undefined,
       confirmOptions
@@ -92,36 +88,35 @@ export const createCandyMachineOperationHandler: OperationHandler<CreateCandyMac
   },
 };
 
-export type CreateCandyMachineBuilderParams = MetaplexAware & {
-  // Data.
-  candyMachineData: CandyMachineData;
+export type CreateCandyMachineBuilderParams = MetaplexAware &
+  CandyMachineData & {
+    // Accounts.
+    candyMachineSigner: Signer;
+    payerSigner: Signer;
+    walletAddress: PublicKey;
+    authorityAddress: PublicKey;
 
-  // Accounts.
-  candyMachineSigner: Signer;
-  payerSigner: Signer;
-  walletAddress: PublicKey;
-  authorityAddress: PublicKey;
+    // Instruction keys.
+    createAccountInstructionKey?: string;
+    initializeCandyMachineInstructionKey?: string;
 
-  // Instruction keys.
-  createAccountInstructionKey?: string;
-  initializeCandyMachineInstructionKey?: string;
-
-  // Transaction Options.
-  confirmOptions?: ConfirmOptions;
-};
+    // Transaction Options.
+    confirmOptions?: ConfirmOptions;
+  };
 
 export const createCandyMachineBuilder = async (
   params: CreateCandyMachineBuilderParams
 ): Promise<TransactionBuilder> => {
   const {
     metaplex,
-    candyMachineData,
     candyMachineSigner,
     payerSigner,
     walletAddress,
     authorityAddress,
     createAccountInstructionKey,
     initializeCandyMachineInstructionKey,
+
+    ...candyMachineData
   } = params;
 
   const space = getSpaceForCandy(candyMachineData);

--- a/src/plugins/candyMachineModule/findCandyMachineByAddress.ts
+++ b/src/plugins/candyMachineModule/findCandyMachineByAddress.ts
@@ -4,22 +4,31 @@ import { CandyMachine } from './CandyMachine';
 import { Metaplex } from '@/Metaplex';
 import { CandyMachineAccount } from '@/programs';
 
+// -----------------
+// Operation
+// -----------------
 const Key = 'FindCandyMachineByAdddressOperation' as const;
+
 export const findCandyMachineByAdddressOperation =
   useOperation<FindCandyMachineByAdddressOperation>(Key);
-export type FindCandyMachineByAdddressOperation = Operation<typeof Key, PublicKey, CandyMachine>;
 
+export type FindCandyMachineByAdddressOperation = Operation<
+  typeof Key,
+  PublicKey,
+  CandyMachine | null
+>;
+
+// -----------------
+// Handler
+// -----------------
 export const findCandyMachineByAdddressOperationHandler: OperationHandler<FindCandyMachineByAdddressOperation> =
   {
     handle: async (operation: FindCandyMachineByAdddressOperation, metaplex: Metaplex) => {
       const candyMachineAddress = operation.input;
+      const unparsedAccount = await metaplex.rpc().getAccount(candyMachineAddress);
 
-      // TODO(loris): Always use the metaplex.rpc() to interact with the cluster.
-      const account = await CandyMachineAccount.fromAccountAddress(
-        metaplex.connection,
-        candyMachineAddress
-      );
+      const account = CandyMachineAccount.fromMaybe(unparsedAccount);
 
-      return CandyMachine.fromAccount(account);
+      return account.exists ? CandyMachine.fromAccount(account) : null;
     },
   };

--- a/src/plugins/candyMachineModule/index.ts
+++ b/src/plugins/candyMachineModule/index.ts
@@ -1,3 +1,4 @@
+export * from './config';
 export * from './CandyMachine';
 export * from './CandyMachineClient';
 export * from './createCandyMachine';

--- a/src/plugins/candyMachineModule/plugin.ts
+++ b/src/plugins/candyMachineModule/plugin.ts
@@ -16,7 +16,7 @@ export const candyMachineModule = (): MetaplexPlugin => ({
     op.register(createCandyMachineOperation, createCandyMachineOperationHandler);
     op.register(findCandyMachineByAdddressOperation, findCandyMachineByAdddressOperationHandler);
 
-    metaplex.candyMachine = function () {
+    metaplex.candyMachines = function () {
       return new CandyMachineClient(this);
     };
   },
@@ -24,6 +24,6 @@ export const candyMachineModule = (): MetaplexPlugin => ({
 
 declare module '../../Metaplex' {
   interface Metaplex {
-    candyMachine(): CandyMachineClient;
+    candyMachines(): CandyMachineClient;
   }
 }

--- a/src/programs/candyMachine/accounts/CandyMachineAccount.ts
+++ b/src/programs/candyMachine/accounts/CandyMachineAccount.ts
@@ -1,6 +1,5 @@
-import { Connection, PublicKey } from '@solana/web3.js';
 import { CandyMachine } from '@metaplex-foundation/mpl-candy-machine';
-import { BaseAccount } from '@/types';
+import { BaseAccount, UnparsedAccount, UnparsedMaybeAccount } from '@/types';
 import { getSpaceForCandy } from './candyMachineSpace';
 
 export class CandyMachineAccount extends BaseAccount<CandyMachine> {
@@ -8,18 +7,11 @@ export class CandyMachineAccount extends BaseAccount<CandyMachine> {
     return getSpaceForCandy(this.data.data);
   }
 
-  static async fromAccountAddress(
-    connection: Connection,
-    address: PublicKey
-  ): Promise<CandyMachineAccount> {
-    // TODO(thlorenz): should pass in UnparsedAccount here which is obtained
-    // via the `metaplex.rpc()` driver
-    const accountInfo = await connection.getAccountInfo(address);
-    if (accountInfo == null) {
-      throw new Error(`Unable to find CandyMachine account at ${address}`);
-    }
-    const unparsedAccount = { ...accountInfo, publicKey: address };
-    const parsed = CandyMachineAccount.parse(unparsedAccount, CandyMachine);
-    return new CandyMachineAccount(parsed);
+  static from(unparsedAccount: UnparsedAccount) {
+    return new CandyMachineAccount(CandyMachineAccount.parse(unparsedAccount, CandyMachine));
+  }
+
+  static fromMaybe(maybe: UnparsedMaybeAccount) {
+    return maybe.exists ? CandyMachineAccount.from(maybe) : maybe;
   }
 }

--- a/src/types/DateTimeString.ts
+++ b/src/types/DateTimeString.ts
@@ -14,7 +14,7 @@ export type DateTimeString = string;
  * @throws {@link Error} if the {@link dateTimeString} is not a valid date/time string.
  * @private
  */
-export function tryConvertToMillisecondsSinceEpoch(dateTimeString: DateTimeString): BN {
+export function convertToMillisecondsSinceEpoch(dateTimeString: DateTimeString): BN {
   const date = new Date(dateTimeString);
   const msSinceEpoch = date.valueOf();
   return new BN(msSinceEpoch);

--- a/src/types/IdentityDriver.ts
+++ b/src/types/IdentityDriver.ts
@@ -14,7 +14,7 @@ export abstract class IdentityDriver extends Driver implements IdentitySigner {
   }
 
   public equals(that: Signer | PublicKey): boolean {
-    if (!(that instanceof PublicKey)) {
+    if ('publicKey' in that) {
       that = that.publicKey;
     }
 

--- a/src/types/PublicKeyString.ts
+++ b/src/types/PublicKeyString.ts
@@ -45,8 +45,9 @@ export function isPublicKeyString(value: string): value is PublicKeyString {
  * @throws {@link AssertionError} if the {@link value} is not a valid base58 string for a PublicKey of a Solana
  * Account.
  * @private
+ * @throws if value is not a valid PublicKey address
  */
-export function tryConvertToPublickKey(value: PublicKeyString): PublicKey {
+export function convertToPublickKey(value: PublicKeyString): PublicKey {
   assert(isPublicKeyString(value), `${value} is not a valid PublicKey`);
   return new PublicKey(value);
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,8 +1,2 @@
-export class UnreachableCaseError extends Error {
-  constructor(value: never) {
-    super(`Unreachable case: ${value}`);
-  }
-}
-
 export type Optional<T extends object, K extends keyof T = keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;

--- a/test/plugins/candyMachineModule/createCandyMachine.test.ts
+++ b/test/plugins/candyMachineModule/createCandyMachine.test.ts
@@ -52,7 +52,7 @@ async function init() {
   };
   await amman.addr.addLabels({ ...minimalConfig, ...opts, payer });
 
-  const cm = mx.candyMachine();
+  const cm = mx.candyMachines();
   return { cm, payer, solTreasuryAccount, minimalConfig, opts };
 }
 


### PR DESCRIPTION
## Summary

FIXES: #91 by addressing each requested change

## Details of Addressed Requests

- removed `try` prefixes
- refactor of `convertToPublicKey` put off in order to gain more insight into use cases and
  ideally find an existing implementation instead of hand rolling our own
- provide `DateTime` input for multiple formats also put off for same reasons
- `UnreachableCaseError` is now an `SDKError`
- `findCandyMachine` now uses metaplex rpc
- `CandyMachineData` now is no longer a `data` property but has its fields spread out
  - held off on deciding what's optional + detailed field docs as I want to discover this via
    use cases (that don't provide a candy machine config)

## Additional Changes

- replaced `instanceof` with `is` as that works across web3.js versions for the `PublicKey`
  `equals` method
- properly handling case for a candy machine that was just created, but now cannot be found via
  a custom Metaplex Error created for that case
- exposing candy machine client under `candyMachines`