### PR TITLE
chore: update beet and amman + update tests to amman API

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.1",
     "@bundlr-network/client": "^0.7.3",
-    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet": "^0.2.0",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/mpl-candy-machine": "^4.2.0",
     "@metaplex-foundation/mpl-token-metadata": "^2.1.1",
@@ -76,7 +76,7 @@
     "@babel/core": "^7.17.10",
     "@babel/preset-env": "^7.17.10",
     "@babel/preset-typescript": "^7.16.7",
-    "@metaplex-foundation/amman": "^0.6.1",
+    "@metaplex-foundation/amman": "^0.8.2",
     "@ovos-media/ts-transform-paths": "^1.7.18-1",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/test/helpers/asserts.ts
+++ b/test/helpers/asserts.ts
@@ -1,10 +1,8 @@
-import { PublicKey, RpcResponseAndContext, SignatureResult } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { bignum } from '@metaplex-foundation/beet';
-import { cusper as cusperTokenMetadata } from '@metaplex-foundation/mpl-token-metadata';
 import BN from 'bn.js';
 import { Specification, Specifications } from 'spok';
 import { Test } from 'tape';
-import { resolveTransactionError } from './amman';
 
 export function spokSamePubkey(
   a: PublicKey | string | null | undefined
@@ -27,18 +25,6 @@ export function spokSameBignum(a: BN | bignum | number | null | undefined): Spec
   same.$spec = `spokSameBignum(${a})`;
   same.$description = `${a} equal`;
   return same;
-}
-
-export function assertConfirmedWithoutError(
-  t: Test,
-  cusper: typeof cusperTokenMetadata,
-  confirmed: RpcResponseAndContext<SignatureResult>
-) {
-  if (confirmed.value.err == null) {
-    t.pass('confirmed without error');
-  } else {
-    t.fail(resolveTransactionError(cusper, confirmed.value.err).stack);
-  }
 }
 
 async function assertThrowsOnResolve<T>(

--- a/test/plugins/candyMachineModule/updateCandyMachine.test.ts
+++ b/test/plugins/candyMachineModule/updateCandyMachine.test.ts
@@ -1,17 +1,9 @@
 import test from 'tape';
 import spok from 'spok';
-import {
-  amman,
-  assertConfirmedWithoutError,
-  killStuckProcess,
-  metaplex,
-  spokSameBignum,
-  spokSamePubkey,
-} from '../../helpers';
+import { amman, killStuckProcess, metaplex, spokSameBignum, spokSamePubkey } from '../../helpers';
 import { createCandyMachineWithMinimalConfig } from './helpers';
 import {
   CandyMachineData,
-  cusper,
   EndSettingType,
   WhitelistMintMode,
 } from '@metaplex-foundation/mpl-candy-machine';
@@ -53,6 +45,7 @@ test('update: candy machine single property', async (t) => {
   // Given I create one candy machine
   const mx = await metaplex();
   const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
 
   const { candyMachineSigner, payerSigner, walletAddress, candyMachine } =
     await createCandyMachineWithMinimalConfig(mx);
@@ -72,7 +65,7 @@ test('update: candy machine single property', async (t) => {
     t.comment(`Updating ${key}`);
 
     // When I update that candy machine's property
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -81,7 +74,7 @@ test('update: candy machine single property', async (t) => {
     await amman.addr.addLabel(`tx: update-cm-${key}`, transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -95,6 +88,7 @@ test('update: candy machine multiple scalar properties', async (t) => {
   // Given I create one candy machine
   const mx = await metaplex();
   const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
   const { candyMachineSigner, payerSigner, walletAddress, candyMachine } =
     await createCandyMachineWithMinimalConfig(mx);
 
@@ -136,7 +130,7 @@ test('update: candy machine multiple scalar properties', async (t) => {
     t.comment(`Updating ${keys.join(', ')}`);
 
     // When I update that candy machine's property
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -145,7 +139,7 @@ test('update: candy machine multiple scalar properties', async (t) => {
     await amman.addr.addLabel(`tx: update-cm-${keys.join(', ')}`, transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -167,6 +161,7 @@ test('update: candy machine end settings', async (t) => {
   // Given I create one candy machine without end settings
   const mx = await metaplex();
   const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
 
   const { candyMachineSigner, payerSigner, walletAddress, candyMachine } =
     await createCandyMachineWithMinimalConfig(mx);
@@ -181,7 +176,7 @@ test('update: candy machine end settings', async (t) => {
       },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -190,7 +185,7 @@ test('update: candy machine end settings', async (t) => {
     await amman.addr.addLabel('tx: add-cm-end-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -215,7 +210,7 @@ test('update: candy machine end settings', async (t) => {
       },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -224,7 +219,7 @@ test('update: candy machine end settings', async (t) => {
     await amman.addr.addLabel('tx: update-cm-end-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -246,7 +241,7 @@ test('update: candy machine end settings', async (t) => {
       endSettings: undefined,
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -255,7 +250,7 @@ test('update: candy machine end settings', async (t) => {
     await amman.addr.addLabel('tx: remove-cm-end-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -280,6 +275,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
   // Given I create one candy machine without gatekeeper settings
   const mx = await metaplex();
   const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
 
   const { candyMachineSigner, payerSigner, walletAddress, candyMachine } =
     await createCandyMachineWithMinimalConfig(mx);
@@ -293,7 +289,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
       gatekeeper: { expireOnUse: true, gatekeeperNetwork: gateKeeper },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -302,7 +298,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
     await amman.addr.addLabel('tx: add-cm-gatekeeper-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -325,7 +321,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
       gatekeeper: { expireOnUse: false, gatekeeperNetwork: gateKeeper },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -334,7 +330,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
     await amman.addr.addLabel('tx: update-cm-gatekeeper-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -356,7 +352,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
       gatekeeper: undefined,
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -365,7 +361,7 @@ test('update: candy machine gatekeeper settings', async (t) => {
     await amman.addr.addLabel('tx: remove-cm-gatekeeper-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -385,6 +381,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
   // Given I create one candy machine without whitelist mint settings
   const mx = await metaplex();
   const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
 
   const { candyMachineSigner, payerSigner, walletAddress, candyMachine } =
     await createCandyMachineWithMinimalConfig(mx);
@@ -403,7 +400,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
       },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -412,7 +409,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     await amman.addr.addLabel('tx: add-cm-whitelist-mint-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -442,7 +439,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
       },
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -451,7 +448,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     await amman.addr.addLabel('tx: update-cm-whitelist-mint-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);
@@ -475,7 +472,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
       whitelistMintSettings: undefined,
     };
 
-    const { transactionId, confirmResponse } = await cm.update({
+    const { transactionId } = await cm.update({
       authoritySigner: payerSigner,
       candyMachineAddress: candyMachineSigner.publicKey,
       walletAddress,
@@ -484,7 +481,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     await amman.addr.addLabel('tx: remove-cm-whitelist-mint-settings', transactionId);
 
     // Then the transaction succeeds
-    assertConfirmedWithoutError(t, cusper, confirmResponse);
+    tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx.candyMachines().findByAddress(candyMachineSigner.publicKey);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,10 +2212,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@metaplex-foundation/amman@^0.6.1":
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/@metaplex-foundation/amman/-/amman-0.6.3.tgz"
-  integrity sha512-a0ZdSpTIh6QVFsZY5pnlXnLNXG18FPBcBDotNqFkGqHBZ3YppCcqDulo7wyGufWmunxGK+LJn7cGcC3awyQLhQ==
+"@metaplex-foundation/amman@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/amman/-/amman-0.8.2.tgz#b850bcce862d64e0b6dfa3b030c840b38b79f28d"
+  integrity sha512-PxlpATuWxXF3+wr8LkYPhnTc3w6tK19BFtlgenyVOSb0vOS+DEGHS1/9m1OgK7sCM/+zO5UvMWiM2ZRb9xj/NQ==
   dependencies:
     "@metaplex-foundation/cusper" "^0.0.2"
     "@metaplex-foundation/js-next" "^0.7.2"
@@ -2228,6 +2228,7 @@
     date-fns "^2.28.0"
     debug "^4.3.3"
     deep-diff "^1.0.2"
+    diff "^5.0.0"
     numeral "^2.0.6"
     port-pid "^0.0.7"
     socket.io "^4.4.1"
@@ -2246,9 +2247,9 @@
     "@metaplex-foundation/beet" ">=0.1.0"
     "@solana/web3.js" "^1.31.0"
 
-"@metaplex-foundation/beet@>=0.1.0":
+"@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.2.0":
   version "0.2.0"
-  resolved "https://registry.npmjs.org/@metaplex-foundation/beet/-/beet-0.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.2.0.tgz#e543e17fd1c4dc1251e9aea481a7429bc73f70b8"
   integrity sha512-H570hkJxmx/FxET1OggPPLkPL7psYQa71rNI9NJjYRM8WXdrEvmI/IRIEUW2KR6RqwWWN3FvlRHnKoQUV/lQtA==
   dependencies:
     ansicolors "^0.3.2"


### PR DESCRIPTION
- deps: upgrade amman and beet
- candy-machine: updating to improved amman API
- chore: remove obsolete assertion helper
