### PR TITLE
feat: candy machine update authority

### DIFF
--- a/src/errors/CandyMachineError.ts
+++ b/src/errors/CandyMachineError.ts
@@ -140,3 +140,18 @@ export class MoreThanOneCandyMachineFoundByAuthorityAndUuidError extends CandyMa
     });
   }
 }
+
+export class CandyMachineAlreadyHasThisAuthorityError extends CandyMachineError {
+  constructor(authorityAddress: PublicKey, cause?: Error) {
+    super({
+      cause,
+      key: 'candy_machine_already_has_this_authority',
+      title: 'Candy Machine Already Has This Authority',
+      problem:
+        'The current authority of the candy machine is the same as the new authority provided: ' +
+        `[${authorityAddress.toBase58()}].`,
+      solution:
+        'Double check the new authority you want to use for this Candy Machine.',
+    });
+  }
+}

--- a/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -1,6 +1,7 @@
 import { ConfirmOptions, Keypair, PublicKey } from '@solana/web3.js';
 import { ModuleClient, Signer, convertToPublickKey } from '@/types';
 import {
+  CandyMachineAlreadyHasThisAuthorityError,
   CandyMachinesNotFoundByAuthorityError,
   CandyMachineToUpdateNotFoundError,
   CreatedCandyMachineNotFoundError,
@@ -154,7 +155,7 @@ export class CandyMachineClient extends ModuleClient {
     const currentCandyMachine = await this.findByAddress(
       input.candyMachineAddress
     );
-    if (currentCandyMachine === null) {
+    if (currentCandyMachine == null) {
       throw new CandyMachineToUpdateNotFoundError(input.candyMachineAddress);
     }
 
@@ -174,6 +175,21 @@ export class CandyMachineClient extends ModuleClient {
   async updateAuthority(
     input: UpdateCandyMachineAuthorityParams
   ): Promise<UpdateAuthorityOutput & { candyMachine: CandyMachine }> {
+    const currentCandyMachine = await this.findByAddress(
+      input.candyMachineAddress
+    );
+    if (currentCandyMachine == null) {
+      throw new CandyMachineToUpdateNotFoundError(input.candyMachineAddress);
+    }
+
+    if (
+      currentCandyMachine.authorityAddress.equals(input.newAuthorityAddress)
+    ) {
+      throw new CandyMachineAlreadyHasThisAuthorityError(
+        input.newAuthorityAddress
+      );
+    }
+
     const operation = updateAuthorityOperation(input);
     const output = await this.metaplex.operations().execute(operation);
 

--- a/src/plugins/candyMachineModule/CandyMachineClient.ts
+++ b/src/plugins/candyMachineModule/CandyMachineClient.ts
@@ -26,6 +26,11 @@ import {
   UpdateCandyMachineOutput,
 } from './updateCandyMachine';
 import { CandyMachineData } from '@metaplex-foundation/mpl-candy-machine';
+import {
+  UpdateAuthorityInput,
+  updateAuthorityOperation,
+  UpdateAuthorityOutput,
+} from './updateAuthority';
 
 export type CandyMachineInitFromConfigOpts = {
   candyMachineSigner?: Signer;
@@ -34,6 +39,8 @@ export type CandyMachineInitFromConfigOpts = {
 };
 export type UpdateCandyMachineParams =
   UpdateCandyMachineInputWithoutCandyMachineData & Partial<CandyMachineData>;
+
+export type UpdateCandyMachineAuthorityParams = UpdateAuthorityInput;
 
 export class CandyMachineClient extends ModuleClient {
   // -----------------
@@ -157,7 +164,21 @@ export class CandyMachineClient extends ModuleClient {
     const output = await this.metaplex.operations().execute(operation);
 
     const candyMachine = await this.findByAddress(input.candyMachineAddress);
-    if (candyMachine === null) {
+    if (candyMachine == null) {
+      throw new UpdatedCandyMachineNotFoundError(input.candyMachineAddress);
+    }
+
+    return { candyMachine, ...output };
+  }
+
+  async updateAuthority(
+    input: UpdateCandyMachineAuthorityParams
+  ): Promise<UpdateAuthorityOutput & { candyMachine: CandyMachine }> {
+    const operation = updateAuthorityOperation(input);
+    const output = await this.metaplex.operations().execute(operation);
+
+    const candyMachine = await this.findByAddress(input.candyMachineAddress);
+    if (candyMachine == null) {
       throw new UpdatedCandyMachineNotFoundError(input.candyMachineAddress);
     }
 

--- a/src/plugins/candyMachineModule/plugin.ts
+++ b/src/plugins/candyMachineModule/plugin.ts
@@ -14,6 +14,10 @@ import {
   findCandyMachinesByPublicKeyFieldOnChainOperationHandler,
 } from './findCandyMachinesByPublicKeyField';
 import {
+  updateAuthorityOperation,
+  updateAuthorityOperationHandler,
+} from './updateAuthority';
+import {
   updateCandyMachineOperation,
   updateCandyMachineOperationHandler,
 } from './updateCandyMachine';
@@ -37,6 +41,7 @@ export const candyMachineModule = (): MetaplexPlugin => ({
       updateCandyMachineOperation,
       updateCandyMachineOperationHandler
     );
+    op.register(updateAuthorityOperation, updateAuthorityOperationHandler);
 
     metaplex.candyMachines = function () {
       return new CandyMachineClient(this);

--- a/src/plugins/candyMachineModule/updateAuthority.ts
+++ b/src/plugins/candyMachineModule/updateAuthority.ts
@@ -1,41 +1,39 @@
-import { CandyMachineData } from '@metaplex-foundation/mpl-candy-machine';
+import { Operation, OperationHandler, Signer, useOperation } from '@/types';
+import { Metaplex } from '@/Metaplex';
+import { updateAuthorityBuilder } from '@/programs';
 import {
   ConfirmOptions,
   PublicKey,
   RpcResponseAndContext,
   SignatureResult,
 } from '@solana/web3.js';
-import { Operation, OperationHandler, Signer, useOperation } from '@/types';
-import { updateCandyMachineBuilder } from '@/programs';
-import { Metaplex } from '@/Metaplex';
 
 // -----------------
 // Operation
 // -----------------
-const Key = 'UpdateCandyMachineOperation' as const;
-export const updateCandyMachineOperation =
-  useOperation<UpdateCandyMachineOperation>(Key);
+const Key = 'UpdateAuthorityOperation' as const;
+export const updateAuthorityOperation =
+  useOperation<UpdateAuthorityOperation>(Key);
 
-export type UpdateCandyMachineOperation = Operation<
+export type UpdateAuthorityOperation = Operation<
   typeof Key,
-  UpdateCandyMachineInput,
-  UpdateCandyMachineOutput
+  UpdateAuthorityInput,
+  UpdateAuthorityOutput
 >;
 
-export type UpdateCandyMachineInputWithoutCandyMachineData = {
+export type UpdateAuthorityInput = {
   // Accounts
   candyMachineAddress: PublicKey;
   walletAddress: PublicKey;
   authoritySigner: Signer;
 
+  // Args
+  newAuthorityAddress: PublicKey;
+
   // Transaction Options.
   confirmOptions?: ConfirmOptions;
 };
-
-export type UpdateCandyMachineInput =
-  UpdateCandyMachineInputWithoutCandyMachineData & CandyMachineData;
-
-export type UpdateCandyMachineOutput = {
+export type UpdateAuthorityOutput = {
   // Transaction Result.
   transactionId: string;
   confirmResponse: RpcResponseAndContext<SignatureResult>;
@@ -44,30 +42,30 @@ export type UpdateCandyMachineOutput = {
 // -----------------
 // Handler
 // -----------------
-export const updateCandyMachineOperationHandler: OperationHandler<UpdateCandyMachineOperation> =
+export const updateAuthorityOperationHandler: OperationHandler<UpdateAuthorityOperation> =
   {
     async handle(
-      operation: UpdateCandyMachineOperation,
+      operation: UpdateAuthorityOperation,
       metaplex: Metaplex
-    ): Promise<UpdateCandyMachineOutput> {
+    ): Promise<UpdateAuthorityOutput> {
       const {
         candyMachineAddress,
         walletAddress,
         authoritySigner,
         confirmOptions,
-        ...candyMachineData
+        newAuthorityAddress,
       } = operation.input;
 
       const { signature, confirmResponse } = await metaplex
         .rpc()
         .sendAndConfirmTransaction(
-          updateCandyMachineBuilder({
+          updateAuthorityBuilder({
             candyMachine: candyMachineAddress,
             wallet: walletAddress,
             authority: authoritySigner,
-            data: candyMachineData,
+            newAuthority: newAuthorityAddress,
           }),
-          [authoritySigner],
+          undefined,
           confirmOptions
         );
 

--- a/src/plugins/candyMachineModule/updateCandyMachine.ts
+++ b/src/plugins/candyMachineModule/updateCandyMachine.ts
@@ -67,7 +67,7 @@ export const updateCandyMachineOperationHandler: OperationHandler<UpdateCandyMac
             authority: authoritySigner,
             data: candyMachineData,
           }),
-          [authoritySigner],
+          undefined,
           confirmOptions
         );
 

--- a/src/programs/candyMachine/transactionBuilders/index.ts
+++ b/src/programs/candyMachine/transactionBuilders/index.ts
@@ -1,2 +1,3 @@
 export * from './initializeCandyMachineBuilder';
+export * from './updateAuthorityBuilder';
 export * from './updateCandyMachineBuilder';

--- a/src/programs/candyMachine/transactionBuilders/updateAuthorityBuilder.ts
+++ b/src/programs/candyMachine/transactionBuilders/updateAuthorityBuilder.ts
@@ -1,0 +1,41 @@
+import { createUpdateAuthorityInstruction } from '@metaplex-foundation/mpl-candy-machine';
+import { Signer } from '@/types';
+import { TransactionBuilder } from '@/utils';
+import { PublicKey } from '@solana/web3.js';
+
+export type UpdateAuthorityBuilderParams = {
+  // Accounts
+  candyMachine: PublicKey;
+  authority: Signer;
+  wallet: PublicKey;
+
+  // Instruction Args
+  newAuthority: PublicKey;
+
+  instructionKey?: string;
+};
+
+export function updateAuthorityBuilder(
+  params: UpdateAuthorityBuilderParams
+): TransactionBuilder {
+  const {
+    candyMachine,
+    authority,
+    wallet,
+    newAuthority,
+    instructionKey = 'updateCandyMachineAuthority',
+  } = params;
+
+  return TransactionBuilder.make().add({
+    instruction: createUpdateAuthorityInstruction(
+      {
+        candyMachine,
+        authority: authority.publicKey,
+        wallet,
+      },
+      { newAuthority }
+    ),
+    signers: [authority],
+    key: instructionKey,
+  });
+}

--- a/test/plugins/candyMachineModule/updateAuthority.test.ts
+++ b/test/plugins/candyMachineModule/updateAuthority.test.ts
@@ -1,0 +1,75 @@
+import test from 'tape';
+import spok from 'spok';
+import {
+  amman,
+  killStuckProcess,
+  metaplex,
+  spokSamePubkey,
+} from '../../helpers';
+import { createCandyMachineWithMinimalConfig } from './helpers';
+
+killStuckProcess();
+
+test('update: candy machine authority to new authority', async (t) => {
+  // Given I create one candy machine
+  const mx = await metaplex();
+  const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
+
+  const { candyMachineSigner, payerSigner, walletAddress } =
+    await createCandyMachineWithMinimalConfig(mx);
+
+  const [newAuthorityAddress] = await amman.genLabeledKeypair('newAuthority');
+
+  // When I update that candy machine's authority
+  const { transactionId } = await cm.updateAuthority({
+    authoritySigner: payerSigner,
+    candyMachineAddress: candyMachineSigner.publicKey,
+    walletAddress,
+    newAuthorityAddress,
+  });
+  await amman.addr.addLabel(`tx: update-cm-authority`, transactionId);
+
+  // Then the transaction succeeds
+  await tc.assertSuccess(t, transactionId);
+
+  // And the candy machine authority is updated
+  const updatedMachine = await mx
+    .candyMachines()
+    .findByAddress(candyMachineSigner.publicKey);
+
+  spok(t, updatedMachine, {
+    authorityAddress: spokSamePubkey(newAuthorityAddress),
+  });
+});
+
+test('update: candy machine authority to same authority', async (t) => {
+  // Given I create one candy machine
+  const mx = await metaplex();
+  const cm = mx.candyMachines();
+  const tc = amman.transactionChecker(mx.connection);
+
+  const { candyMachineSigner, payerSigner, walletAddress } =
+    await createCandyMachineWithMinimalConfig(mx);
+
+  // When I update that candy machine's authority
+  const { transactionId } = await cm.updateAuthority({
+    authoritySigner: payerSigner,
+    candyMachineAddress: candyMachineSigner.publicKey,
+    walletAddress,
+    newAuthorityAddress: payerSigner.publicKey,
+  });
+  await amman.addr.addLabel(`tx: update-cm-authority`, transactionId);
+
+  // Then the transaction succeeds
+  await tc.assertSuccess(t, transactionId);
+
+  // And the candy machine authority stayed the same
+  const updatedMachine = await mx
+    .candyMachines()
+    .findByAddress(candyMachineSigner.publicKey);
+
+  spok(t, updatedMachine, {
+    authorityAddress: spokSamePubkey(payerSigner.publicKey),
+  });
+});

--- a/test/plugins/candyMachineModule/updateCandyMachine.test.ts
+++ b/test/plugins/candyMachineModule/updateCandyMachine.test.ts
@@ -451,7 +451,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     );
 
     // Then the transaction succeeds
-    tc.assertSuccess(t, transactionId);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx
@@ -497,7 +497,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     );
 
     // Then the transaction succeeds
-    tc.assertSuccess(t, transactionId);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx
@@ -537,7 +537,7 @@ test('update: candy machine whitelist mint settings', async (t) => {
     );
 
     // Then the transaction succeeds
-    tc.assertSuccess(t, transactionId);
+    await tc.assertSuccess(t, transactionId);
 
     // And the candy machine is updated
     const updatedMachine = await mx

--- a/test/plugins/coreRpcDriver/Web3RpcDriver.test.ts
+++ b/test/plugins/coreRpcDriver/Web3RpcDriver.test.ts
@@ -26,6 +26,7 @@ test('rpc-driver: it parses program errors when sending transactions', async (t:
   // Then we receive a parsed program error.
   try {
     await promise;
+    t.fail('Expected a ParsedProgramError');
   } catch (error) {
     t.ok(error instanceof ParsedProgramError);
     t.ok(


### PR DESCRIPTION
# Summary

Adds `updateAuthority` method to `CandyMachineClient`.

Raising error when updating to same authority since most likely not what the user intended.

FIXES: #108