### PR TITLE
Remove wallet adapter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@metaplex-foundation/mpl-candy-machine": "^4.2.0",
     "@metaplex-foundation/mpl-token-metadata": "^2.1.1",
     "@solana/spl-token": "^0.2.0",
-    "@solana/wallet-adapter-base": "^0.9.3",
     "@solana/web3.js": "^1.37.0",
     "abort-controller": "^3.0.0",
     "bignumber.js": "^9.0.2",

--- a/src/plugins/walletAdapterIdentity/WalletAdapterIdentityDriver.ts
+++ b/src/plugins/walletAdapterIdentity/WalletAdapterIdentityDriver.ts
@@ -3,23 +3,30 @@ import {
   PublicKey,
   Transaction,
   TransactionSignature,
+  SendOptions,
 } from '@solana/web3.js';
-import {
-  MessageSignerWalletAdapterProps,
-  SignerWalletAdapterProps,
-  SendTransactionOptions,
-  WalletAdapter as BaseWalletAdapter,
-} from '@solana/wallet-adapter-base';
-import { IdentityDriver } from '@/types';
+import { IdentityDriver, KeypairSigner } from '@/types';
 import { Metaplex } from '@/Metaplex';
 import {
   OperationNotSupportedByWalletAdapterError,
   UninitializedWalletAdapterError,
 } from '@/errors';
 
-export type WalletAdapter = BaseWalletAdapter &
-  Partial<MessageSignerWalletAdapterProps> &
-  Partial<SignerWalletAdapterProps>;
+type SendTransactionOptions = SendOptions & {
+  signers?: KeypairSigner[];
+};
+
+export type WalletAdapter = {
+  publicKey: PublicKey | null;
+  sendTransaction: (
+    transaction: Transaction,
+    connection: Connection,
+    options?: SendTransactionOptions
+  ) => Promise<TransactionSignature>;
+  signMessage?: (message: Uint8Array) => Promise<Uint8Array>;
+  signTransaction?: (transaction: Transaction) => Promise<Transaction>;
+  signAllTransactions?: (transaction: Transaction[]) => Promise<Transaction[]>;
+};
 
 export class WalletAdapterIdentityDriver extends IdentityDriver {
   public readonly walletAdapter: WalletAdapter;


### PR DESCRIPTION
**Currently**: We are requiring the `@solana/wallet-adapter-base` package just to import its `WalletAdapter` type. The issue is we require the entire type when we only need a subset of it. This can cause type errors like #113.

**After this PR**: We expose our own `WalletAdapter` type definition cherry-picking what we need from that library without depending on it.

Fix #113 