### PR TITLE
Implement Derived Identity Plugin

### DIFF
--- a/src/errors/SdkError.ts
+++ b/src/errors/SdkError.ts
@@ -42,6 +42,23 @@ export class DriverNotProvidedError extends SdkError {
   }
 }
 
+export class UnexpectedCurrencyError extends SdkError {
+  actual: Currency;
+  expected: Currency;
+  constructor(actual: Currency, expected: Currency, cause?: Error) {
+    super({
+      cause,
+      key: 'unexpected_currency',
+      title: 'Unexpected Currency',
+      problem: `Expected currency [${expected}] but got [${actual}].`,
+      solution:
+        'Ensure the provided Amount or Currency is of the expected type.',
+    });
+    this.actual = actual;
+    this.expected = expected;
+  }
+}
+
 export class CurrencyMismatchError extends SdkError {
   left: Currency;
   right: Currency;

--- a/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -64,7 +64,7 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
       lamports: amount.basisPoints.toNumber(),
     });
 
-    this.metaplex.rpc().sendAndConfirmTransaction(transfer);
+    await this.metaplex.rpc().sendAndConfirmTransaction(transfer);
   }
 
   async withdraw(amount: Amount): Promise<void> {
@@ -77,7 +77,7 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
       lamports: amount.basisPoints.toNumber(),
     });
 
-    this.metaplex.rpc().sendAndConfirmTransaction(transfer);
+    await this.metaplex.rpc().sendAndConfirmTransaction(transfer);
   }
 
   async withdrawAll(): Promise<void> {
@@ -87,7 +87,7 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
       .rpc()
       .getBalance(this.derivedKeypair.publicKey);
 
-    this.withdraw(balance);
+    await this.withdraw(balance);
   }
 
   close(): void {

--- a/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -33,8 +33,17 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
     return this.derivedKeypair.secretKey;
   }
 
-  async deriveFrom(message: string | Uint8Array): Promise<void> {
-    this.originalSigner = this.metaplex.identity();
+  get originalPublicKey(): PublicKey {
+    this.assertInitialized();
+
+    return this.originalSigner.publicKey;
+  }
+
+  async deriveFrom(
+    message: string | Uint8Array,
+    originalSigner?: IdentitySigner
+  ): Promise<void> {
+    this.originalSigner = originalSigner ?? this.metaplex.identity().driver();
 
     const signature = await this.originalSigner.signMessage(
       Buffer.from(message)

--- a/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -1,0 +1,74 @@
+import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import nacl from 'tweetnacl';
+import { Buffer } from 'buffer';
+import type { Metaplex } from '@/Metaplex';
+import { Amount, IdentitySigner, KeypairSigner } from '@/types';
+
+export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
+  protected readonly metaplex: Metaplex;
+  protected derivedKeypair: Keypair | null = null;
+
+  constructor(metaplex: Metaplex) {
+    this.metaplex = metaplex;
+  }
+
+  get publicKey(): PublicKey {
+    if (this.derivedKeypair === null) {
+      // TODO: Custom errors.
+      throw new Error('Uninitialized derived identity');
+    }
+
+    return this.derivedKeypair.publicKey;
+  }
+
+  get secretKey(): Uint8Array {
+    if (this.derivedKeypair === null) {
+      // TODO: Custom errors.
+      throw new Error('Uninitialized derived identity');
+    }
+
+    return this.derivedKeypair.secretKey;
+  }
+
+  async deriveFrom(message: string): Promise<void> {
+    const signature = await this.metaplex
+      .identity()
+      .signMessage(Buffer.from(message));
+
+    const seeds = nacl.hash(signature).slice(0, 32);
+
+    this.derivedKeypair = Keypair.fromSeed(seeds);
+  }
+
+  fund(amount: Amount): void {
+    // TODO
+  }
+
+  withdraw(amount: Amount): void {
+    // TODO
+  }
+
+  withdrawAll(): void {
+    // TODO
+  }
+
+  public async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    return nacl.sign.detached(message, this.secretKey);
+  }
+
+  public async signTransaction(transaction: Transaction): Promise<Transaction> {
+    // TODO: Handle Error: Transaction recentBlockhash required.
+
+    transaction.partialSign(this);
+
+    return transaction;
+  }
+
+  public async signAllTransactions(
+    transactions: Transaction[]
+  ): Promise<Transaction[]> {
+    return Promise.all(
+      transactions.map((transaction) => this.signTransaction(transaction))
+    );
+  }
+}

--- a/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -81,6 +81,11 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
     this.withdraw(balance);
   }
 
+  close(): void {
+    this.originalSigner = null;
+    this.derivedKeypair = null;
+  }
+
   async signMessage(message: Uint8Array): Promise<Uint8Array> {
     return nacl.sign.detached(message, this.secretKey);
   }
@@ -99,7 +104,23 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
     );
   }
 
-  protected assertInitialized(): asserts this is {
+  verifyMessage(message: Uint8Array, signature: Uint8Array): boolean {
+    return nacl.sign.detached.verify(
+      message,
+      signature,
+      this.publicKey.toBytes()
+    );
+  }
+
+  equals(that: Signer | PublicKey): boolean {
+    if ('publicKey' in that) {
+      that = that.publicKey;
+    }
+
+    return this.publicKey.equals(that);
+  }
+
+  assertInitialized(): asserts this is {
     originalSigner: Signer;
     derivedKeypair: Keypair;
   } {

--- a/src/plugins/derivedIdentity/DerivedIdentityClient.ts
+++ b/src/plugins/derivedIdentity/DerivedIdentityClient.ts
@@ -10,6 +10,7 @@ import {
   Signer,
 } from '@/types';
 import { transferBuilder } from '@/programs';
+import { UninitializedDerivedIdentityError } from './errors';
 
 export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
   protected readonly metaplex: Metaplex;
@@ -85,8 +86,6 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
   }
 
   async signTransaction(transaction: Transaction): Promise<Transaction> {
-    // TODO: Handle Error: Transaction recentBlockhash required.
-
     transaction.partialSign(this);
 
     return transaction;
@@ -105,8 +104,7 @@ export class DerivedIdentityClient implements IdentitySigner, KeypairSigner {
     derivedKeypair: Keypair;
   } {
     if (this.derivedKeypair === null || this.originalSigner === null) {
-      // TODO: Custom errors.
-      throw new Error('Uninitialized derived identity');
+      throw new UninitializedDerivedIdentityError();
     }
   }
 }

--- a/src/plugins/derivedIdentity/errors.ts
+++ b/src/plugins/derivedIdentity/errors.ts
@@ -1,0 +1,16 @@
+import { SdkError } from '@/errors';
+
+export class UninitializedDerivedIdentityError extends SdkError {
+  constructor(cause?: Error) {
+    super({
+      cause,
+      key: 'uninitialized_derived_identity',
+      title: 'Uninitialized Derived Identity',
+      problem: 'The derived identity module has not been initialized.',
+      solution:
+        'Before using the derived identity, you must provide a message that ' +
+        'will be used to derived a Keypair from the current identity. ' +
+        'You may do that by calling "metaplex.derivedIdentity().deriveFrom(message)".',
+    });
+  }
+}

--- a/src/plugins/derivedIdentity/index.ts
+++ b/src/plugins/derivedIdentity/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/src/plugins/derivedIdentity/index.ts
+++ b/src/plugins/derivedIdentity/index.ts
@@ -1,1 +1,3 @@
+export * from './DerivedIdentityClient';
+export * from './errors';
 export * from './plugin';

--- a/src/plugins/derivedIdentity/plugin.ts
+++ b/src/plugins/derivedIdentity/plugin.ts
@@ -2,7 +2,7 @@ import type { Metaplex } from '@/Metaplex';
 import { MetaplexPlugin } from '@/types';
 import { DerivedIdentityClient } from './DerivedIdentityClient';
 
-export const identityModule = (): MetaplexPlugin => ({
+export const derivedIdentity = (): MetaplexPlugin => ({
   install(metaplex: Metaplex) {
     const derivedIdentityClient = new DerivedIdentityClient(metaplex);
     metaplex.derivedIdentity = () => derivedIdentityClient;

--- a/src/plugins/derivedIdentity/plugin.ts
+++ b/src/plugins/derivedIdentity/plugin.ts
@@ -1,0 +1,16 @@
+import type { Metaplex } from '@/Metaplex';
+import { MetaplexPlugin } from '@/types';
+import { DerivedIdentityClient } from './DerivedIdentityClient';
+
+export const identityModule = (): MetaplexPlugin => ({
+  install(metaplex: Metaplex) {
+    const derivedIdentityClient = new DerivedIdentityClient(metaplex);
+    metaplex.derivedIdentity = () => derivedIdentityClient;
+  },
+});
+
+declare module '../../Metaplex' {
+  interface Metaplex {
+    derivedIdentity(): DerivedIdentityClient;
+  }
+}

--- a/src/plugins/identityModule/IdentityClient.ts
+++ b/src/plugins/identityModule/IdentityClient.ts
@@ -41,10 +41,7 @@ export class IdentityClient
     return this.driver().signAllTransactions(transactions);
   }
 
-  public async verifyMessage(
-    message: Uint8Array,
-    signature: Uint8Array
-  ): Promise<boolean> {
+  verifyMessage(message: Uint8Array, signature: Uint8Array): boolean {
     return nacl.sign.detached.verify(
       message,
       signature,
@@ -52,15 +49,15 @@ export class IdentityClient
     );
   }
 
-  hasSecretKey(): this is KeypairSigner {
-    return this.secretKey != null;
-  }
-
-  public equals(that: Signer | PublicKey): boolean {
+  equals(that: Signer | PublicKey): boolean {
     if ('publicKey' in that) {
       that = that.publicKey;
     }
 
     return this.publicKey.equals(that);
+  }
+
+  hasSecretKey(): this is KeypairSigner {
+    return this.secretKey != null;
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -3,6 +3,7 @@ export * from './bundlrStorage';
 export * from './candyMachineModule';
 export * from './corePlugins';
 export * from './corePrograms';
+export * from './derivedIdentity';
 export * from './guestIdentity';
 export * from './keypairIdentity';
 export * from './mockStorage';

--- a/src/plugins/keypairIdentity/KeypairIdentityDriver.ts
+++ b/src/plugins/keypairIdentity/KeypairIdentityDriver.ts
@@ -19,8 +19,6 @@ export class KeypairIdentityDriver implements IdentityDriver, KeypairSigner {
   }
 
   public async signTransaction(transaction: Transaction): Promise<Transaction> {
-    // TODO: Handle Error: Transaction recentBlockhash required.
-
     transaction.partialSign(this.keypair);
 
     return transaction;

--- a/src/plugins/rpcModule/RpcClient.ts
+++ b/src/plugins/rpcModule/RpcClient.ts
@@ -20,6 +20,8 @@ import {
   UnparsedMaybeAccount,
   isErrorWithLogs,
   Program,
+  lamports,
+  Amount,
 } from '@/types';
 import { TransactionBuilder, zipMap } from '@/utils';
 import {
@@ -154,6 +156,18 @@ export class RpcClient {
       publicKey: pubkey,
       ...account,
     }));
+  }
+
+  async getBalance(
+    publicKey: PublicKey,
+    commitment?: Commitment
+  ): Promise<Amount> {
+    const balance = await this.metaplex.connection.getBalance(
+      publicKey,
+      commitment
+    );
+
+    return lamports(balance);
   }
 
   async getLatestBlockhash(): Promise<Blockhash> {

--- a/src/programs/system/transactionBuilders/transferBuilder.ts
+++ b/src/programs/system/transactionBuilders/transferBuilder.ts
@@ -5,7 +5,7 @@ import { TransactionBuilder } from '@/utils';
 export interface transferBuilderParams {
   from: Signer;
   to: PublicKey;
-  lamports: number;
+  lamports: number | bigint;
   basePubkey?: PublicKey;
   seed?: string;
   program?: PublicKey;

--- a/src/types/Amount.ts
+++ b/src/types/Amount.ts
@@ -1,7 +1,7 @@
 import { LAMPORTS_PER_SOL } from '@solana/web3.js';
 import BN from 'bn.js';
 import { Opaque } from '@/utils';
-import { CurrencyMismatchError } from '@/errors';
+import { CurrencyMismatchError, UnexpectedCurrencyError } from '@/errors';
 
 export type Amount = {
   basisPoints: BasisPoints;
@@ -73,6 +73,23 @@ export const sameCurrencies = (
     left.decimals === right.decimals &&
     left.namespace === right.namespace
   );
+};
+
+export const assertCurrency = (
+  actual: Currency | Amount,
+  expected: Currency
+) => {
+  if ('currency' in actual) {
+    actual = actual.currency;
+  }
+
+  if (!sameCurrencies(actual, expected)) {
+    throw new UnexpectedCurrencyError(actual, expected);
+  }
+};
+
+export const assertSol = (actual: Currency | Amount) => {
+  assertCurrency(actual, SOL);
 };
 
 export const assertSameCurrencies = (

--- a/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
+++ b/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
@@ -135,11 +135,9 @@ test('[derivedIdentity] it can fund the derived identity', async (t: Test) => {
   // When we fund the derived identity by 1 SOL.
   await mx.derivedIdentity().fund(sol(1));
 
-  // And fetch the balances of both the identity and the derived identity.
-  const { identityBalance, derivedBalance } = await getBalances(mx);
-
   // Then we can see that 1 SOL was transferred from the identity to the derived identity.
   // It's a little less due to the transaction fee.
+  const { identityBalance, derivedBalance } = await getBalances(mx);
   t.true(isLessThanAmount(identityBalance, sol(4)));
   t.true(isGreaterThanAmount(identityBalance, sol(3.9)));
   t.true(isEqualToAmount(derivedBalance, sol(1)));
@@ -158,12 +156,31 @@ test('[derivedIdentity] it can withdraw from the derived identity', async (t: Te
   // When we withdraw 1 SOL from the derived identity.
   await mx.derivedIdentity().withdraw(sol(1));
 
-  // And fetch the balances of both the identity and the derived identity.
-  const { identityBalance, derivedBalance } = await getBalances(mx);
-
   // Then we can see that 1 SOL was transferred from the derived identity to the identity.
   // It's a little less due to the transaction fee.
+  const { identityBalance, derivedBalance } = await getBalances(mx);
   t.true(isLessThanAmount(identityBalance, sol(6)));
   t.true(isGreaterThanAmount(identityBalance, sol(5.9)));
   t.true(isEqualToAmount(derivedBalance, sol(1)));
+});
+
+test('[derivedIdentity] it can withdraw everything from the derived identity', async (t: Test) => {
+  // Given a Metaplex instance with:
+  // - an identity airdropped with 5 SOLs.
+  // - a derived identity airdropped with 2 SOLs.
+  const mx = await init({
+    message: 'withdraw',
+    identityAirdrop: 5,
+    derivedAirdrop: 2,
+  });
+
+  // When we withdraw everything from the derived identity.
+  await mx.derivedIdentity().withdrawAll();
+
+  // Then we can see that 1 SOL was transferred from the derived identity to the identity.
+  // It's a little less due to the transaction fee.
+  const { identityBalance, derivedBalance } = await getBalances(mx);
+  t.true(isLessThanAmount(identityBalance, sol(7)));
+  t.true(isGreaterThanAmount(identityBalance, sol(6.9)));
+  t.true(isEqualToAmount(derivedBalance, sol(0)));
 });

--- a/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
+++ b/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
@@ -1,6 +1,11 @@
+import { Keypair } from '@solana/web3.js';
 import test, { Test } from 'tape';
 import { killStuckProcess, metaplex } from '../../helpers';
-import { derivedIdentity } from '@/index';
+import {
+  derivedIdentity,
+  keypairIdentity,
+  KeypairIdentityDriver,
+} from '@/index';
 
 killStuckProcess();
 
@@ -16,26 +21,79 @@ const init = async (message?: string) => {
   return mx;
 };
 
-test('[derivedIdentity] it derives the same address when using the same message', async (t: Test) => {
+test('[derivedIdentity] it derives a Keypair from the current identity', async (t: Test) => {
+  // Given a Metaplex instance using the derived identity plugin.
   const mx = await init();
 
+  // When we derive the identity using a message.
+  await mx.derivedIdentity().deriveFrom('Hello World');
+
+  // Then we get a Signer Keypair.
+  t.true(mx.derivedIdentity().publicKey);
+  t.true(mx.derivedIdentity().secretKey);
+
+  // And it is different from the original identity.
+  t.false(mx.derivedIdentity().equals(mx.identity()));
+});
+
+test('[derivedIdentity] it keeps track of the identity it originates from', async (t: Test) => {
+  // Given a Metaplex instance using the derived identity plugin.
+  const mx = await init();
+  const identityPublicKey = mx.identity().publicKey;
+
+  // When we derive the identity.
+  await mx.derivedIdentity().deriveFrom('Hello World');
+
+  // Then the derived identity kept track of the identity it originated from.
+  t.true(identityPublicKey.equals(mx.derivedIdentity().originalPublicKey));
+
+  // Even if we end up updating the identity.
+  mx.use(keypairIdentity(Keypair.generate()));
+  t.true(identityPublicKey.equals(mx.derivedIdentity().originalPublicKey));
+  t.false(mx.identity().equals(mx.derivedIdentity().originalPublicKey));
+});
+
+test('[derivedIdentity] it can derive a Keypair from an explicit IdentitySigner', async (t: Test) => {
+  // Given a Metaplex instance and a custom IdentitySigner.
+  const mx = await init();
+  const signer = new KeypairIdentityDriver(Keypair.generate());
+
+  // When we derive the identity by providing the signer explicitly.
+  await mx.derivedIdentity().deriveFrom('Hello World', signer);
+
+  // Then a new derived identity was created for that signer.
+  t.true(signer.publicKey.equals(mx.derivedIdentity().originalPublicKey));
+
+  // But not for the current identity.
+  t.false(mx.identity().equals(mx.derivedIdentity().originalPublicKey));
+});
+
+test('[derivedIdentity] it derives the same address when using the same message', async (t: Test) => {
+  // Given a Metaplex instance using the derived identity plugin.
+  const mx = await init();
+
+  // When we derive the identity twice with the same message.
   await mx.derivedIdentity().deriveFrom('Hello World');
   const derivedPublicKeyA = mx.derivedIdentity().publicKey;
 
   await mx.derivedIdentity().deriveFrom('Hello World');
   const derivedPubliKeyB = mx.derivedIdentity().publicKey;
 
+  // Then we get the same Keypair.
   t.true(derivedPublicKeyA.equals(derivedPubliKeyB));
 });
 
 test('[derivedIdentity] it derives different addresses from different messages', async (t: Test) => {
+  // Given a Metaplex instance using the derived identity plugin.
   const mx = await init();
 
+  // When we derive the identity twice with different messages.
   await mx.derivedIdentity().deriveFrom('Hello World');
   const derivedPublicKeyA = mx.derivedIdentity().publicKey;
 
   await mx.derivedIdentity().deriveFrom('Hello Papito');
   const derivedPubliKeyB = mx.derivedIdentity().publicKey;
 
+  // Then we get the different Keypairs.
   t.false(derivedPublicKeyA.equals(derivedPubliKeyB));
 });

--- a/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
+++ b/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
@@ -1,0 +1,41 @@
+import test, { Test } from 'tape';
+import { killStuckProcess, metaplex } from '../../helpers';
+import { derivedIdentity } from '@/index';
+
+killStuckProcess();
+
+const init = async (message?: string) => {
+  const mx = await metaplex();
+
+  mx.use(derivedIdentity());
+
+  if (message != null) {
+    await mx.derivedIdentity().deriveFrom(message);
+  }
+
+  return mx;
+};
+
+test('[derivedIdentity] it derives the same address when using the same message', async (t: Test) => {
+  const mx = await init();
+
+  await mx.derivedIdentity().deriveFrom('Hello World');
+  const derivedPublicKeyA = mx.derivedIdentity().publicKey;
+
+  await mx.derivedIdentity().deriveFrom('Hello World');
+  const derivedPubliKeyB = mx.derivedIdentity().publicKey;
+
+  t.true(derivedPublicKeyA.equals(derivedPubliKeyB));
+});
+
+test('[derivedIdentity] it derives different addresses from different messages', async (t: Test) => {
+  const mx = await init();
+
+  await mx.derivedIdentity().deriveFrom('Hello World');
+  const derivedPublicKeyA = mx.derivedIdentity().publicKey;
+
+  await mx.derivedIdentity().deriveFrom('Hello Papito');
+  const derivedPubliKeyB = mx.derivedIdentity().publicKey;
+
+  t.false(derivedPublicKeyA.equals(derivedPubliKeyB));
+});

--- a/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
+++ b/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
@@ -57,11 +57,14 @@ test('[derivedIdentity] it derives a Keypair from the current identity', async (
   await mx.derivedIdentity().deriveFrom('Hello World');
 
   // Then we get a Signer Keypair.
-  t.true(mx.derivedIdentity().publicKey);
-  t.true(mx.derivedIdentity().secretKey);
+  t.ok(mx.derivedIdentity().publicKey, 'derived identity has a public key');
+  t.ok(mx.derivedIdentity().secretKey, 'derived identity has a public key');
 
   // And it is different from the original identity.
-  t.false(mx.derivedIdentity().equals(mx.identity()));
+  t.notOk(
+    mx.derivedIdentity().equals(mx.identity()),
+    'derived identity is different from original identity'
+  );
 });
 
 test('[derivedIdentity] it keeps track of the identity it originates from', async (t: Test) => {
@@ -73,12 +76,21 @@ test('[derivedIdentity] it keeps track of the identity it originates from', asyn
   await mx.derivedIdentity().deriveFrom('Hello World');
 
   // Then the derived identity kept track of the identity it originated from.
-  t.true(identityPublicKey.equals(mx.derivedIdentity().originalPublicKey));
+  t.ok(
+    identityPublicKey.equals(mx.derivedIdentity().originalPublicKey),
+    'derived identity stores the public key of the identity it originated from'
+  );
 
   // Even if we end up updating the identity.
   mx.use(keypairIdentity(Keypair.generate()));
-  t.true(identityPublicKey.equals(mx.derivedIdentity().originalPublicKey));
-  t.false(mx.identity().equals(mx.derivedIdentity().originalPublicKey));
+  t.ok(
+    identityPublicKey.equals(mx.derivedIdentity().originalPublicKey),
+    'derived identity stores the public key of the identity it originated from even after it changed'
+  );
+  t.notOk(
+    mx.identity().equals(mx.derivedIdentity().originalPublicKey),
+    "derived identity's stored identity is different to the new identity"
+  );
 });
 
 test('[derivedIdentity] it can derive a Keypair from an explicit IdentitySigner', async (t: Test) => {
@@ -90,10 +102,16 @@ test('[derivedIdentity] it can derive a Keypair from an explicit IdentitySigner'
   await mx.derivedIdentity().deriveFrom('Hello World', signer);
 
   // Then a new derived identity was created for that signer.
-  t.true(signer.publicKey.equals(mx.derivedIdentity().originalPublicKey));
+  t.ok(
+    signer.publicKey.equals(mx.derivedIdentity().originalPublicKey),
+    'derived identity stores the public key of the provided signer'
+  );
 
   // But not for the current identity.
-  t.false(mx.identity().equals(mx.derivedIdentity().originalPublicKey));
+  t.notOk(
+    mx.identity().equals(mx.derivedIdentity().originalPublicKey),
+    'derived identity does not store the public key of the current identity'
+  );
 });
 
 test('[derivedIdentity] it derives the same address when using the same message', async (t: Test) => {
@@ -108,7 +126,10 @@ test('[derivedIdentity] it derives the same address when using the same message'
   const derivedPubliKeyB = mx.derivedIdentity().publicKey;
 
   // Then we get the same Keypair.
-  t.true(derivedPublicKeyA.equals(derivedPubliKeyB));
+  t.ok(
+    derivedPublicKeyA.equals(derivedPubliKeyB),
+    'the two derived identities are the same'
+  );
 });
 
 test('[derivedIdentity] it derives different addresses from different messages', async (t: Test) => {
@@ -123,7 +144,10 @@ test('[derivedIdentity] it derives different addresses from different messages',
   const derivedPubliKeyB = mx.derivedIdentity().publicKey;
 
   // Then we get the different Keypairs.
-  t.false(derivedPublicKeyA.equals(derivedPubliKeyB));
+  t.notOk(
+    derivedPublicKeyA.equals(derivedPubliKeyB),
+    'the two derived identities are different'
+  );
 });
 
 test('[derivedIdentity] it can fund the derived identity', async (t: Test) => {
@@ -138,9 +162,15 @@ test('[derivedIdentity] it can fund the derived identity', async (t: Test) => {
   // Then we can see that 1 SOL was transferred from the identity to the derived identity.
   // It's a little less due to the transaction fee.
   const { identityBalance, derivedBalance } = await getBalances(mx);
-  t.true(isLessThanAmount(identityBalance, sol(4)));
-  t.true(isGreaterThanAmount(identityBalance, sol(3.9)));
-  t.true(isEqualToAmount(derivedBalance, sol(1)));
+  t.ok(
+    isLessThanAmount(identityBalance, sol(4)),
+    'identity balance is less than 4'
+  );
+  t.ok(
+    isGreaterThanAmount(identityBalance, sol(3.9)),
+    'identity balance is greater than 3.9'
+  );
+  t.ok(isEqualToAmount(derivedBalance, sol(1)), 'derived balance is 1');
 });
 
 test('[derivedIdentity] it can withdraw from the derived identity', async (t: Test) => {
@@ -159,9 +189,15 @@ test('[derivedIdentity] it can withdraw from the derived identity', async (t: Te
   // Then we can see that 1 SOL was transferred from the derived identity to the identity.
   // It's a little less due to the transaction fee.
   const { identityBalance, derivedBalance } = await getBalances(mx);
-  t.true(isLessThanAmount(identityBalance, sol(6)));
-  t.true(isGreaterThanAmount(identityBalance, sol(5.9)));
-  t.true(isEqualToAmount(derivedBalance, sol(1)));
+  t.ok(
+    isLessThanAmount(identityBalance, sol(6)),
+    'identity balance is less than 6'
+  );
+  t.ok(
+    isGreaterThanAmount(identityBalance, sol(5.9)),
+    'identity balance is greater than 5.9'
+  );
+  t.ok(isEqualToAmount(derivedBalance, sol(1)), 'derived balance is 1');
 });
 
 test('[derivedIdentity] it can withdraw everything from the derived identity', async (t: Test) => {
@@ -180,7 +216,13 @@ test('[derivedIdentity] it can withdraw everything from the derived identity', a
   // Then we can see that 1 SOL was transferred from the derived identity to the identity.
   // It's a little less due to the transaction fee.
   const { identityBalance, derivedBalance } = await getBalances(mx);
-  t.true(isLessThanAmount(identityBalance, sol(7)));
-  t.true(isGreaterThanAmount(identityBalance, sol(6.9)));
-  t.true(isEqualToAmount(derivedBalance, sol(0)));
+  t.ok(
+    isLessThanAmount(identityBalance, sol(7)),
+    'identity balance is less than 7'
+  );
+  t.ok(
+    isGreaterThanAmount(identityBalance, sol(6.9)),
+    'identity balance is greater than 6.9'
+  );
+  t.ok(isEqualToAmount(derivedBalance, sol(0)), 'derived balance is 0');
 });

--- a/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
+++ b/test/plugins/derivedIdentity/DerivedIdentityClient.test.ts
@@ -58,7 +58,7 @@ test('[derivedIdentity] it derives a Keypair from the current identity', async (
 
   // Then we get a Signer Keypair.
   t.ok(mx.derivedIdentity().publicKey, 'derived identity has a public key');
-  t.ok(mx.derivedIdentity().secretKey, 'derived identity has a public key');
+  t.ok(mx.derivedIdentity().secretKey, 'derived identity has a secret key');
 
   // And it is different from the original identity.
   t.notOk(


### PR DESCRIPTION
This PR implements a new plugin to make it easy for developers to use the **derived keypair pattern** with the SDK.

It provides a `derivedIdentity()` client that contains the following methods.

```ts
metaplex.derivedIdentity() // DerivedIdentityClient
metaplex.derivedIdentity().deriveFrom(message) // Promise<void>
metaplex.derivedIdentity().fund(amount) // Promise<void>
metaplex.derivedIdentity().withdraw(amount) // Promise<void>
metaplex.derivedIdentity().withdrawAll() // Promise<void>
metaplex.derivedIdentity().close() // void

metaplex.derivedIdentity().signTransaction(...) // Promise<Transaction>
metaplex.derivedIdentity().signAllTransactions(...) // Promise<Transaction[]>
metaplex.derivedIdentity().signMessage(...) // Promise<Uint8Array>
metaplex.derivedIdentity().verifyMessage(...) // boolean
metaplex.derivedIdentity().equals(...) // boolean
```

As you can see, once the `deriveFrom` method has been called, you can use the `derivedIdentity()` client just like you would use the `identity()` client. You can also fund the derived identity using the current identity and withdraw from it.

Note that, the `derivedIdentity()` client will throw a `UninitializedDerivedIdentityError` when trying to access methods before calling `deriveFrom`.

Fix #115 