### PR TITLE
Fetch PDAs synchronously

### DIFF
--- a/src/plugins/nftModule/createNft.ts
+++ b/src/plugins/nftModule/createNft.ts
@@ -100,8 +100,8 @@ export const createNftOperationHandler: OperationHandler<CreateNftOperation> = {
       updateAuthority.publicKey
     );
 
-    const metadataPda = await MetadataAccount.pda(mint.publicKey);
-    const masterEditionPda = await OriginalEditionAccount.pda(mint.publicKey);
+    const metadataPda = MetadataAccount.pda(mint.publicKey);
+    const masterEditionPda = OriginalEditionAccount.pda(mint.publicKey);
     const lamports = await getMinimumBalanceForRentExemptMint(
       metaplex.connection
     );

--- a/src/plugins/nftModule/findNftByMint.ts
+++ b/src/plugins/nftModule/findNftByMint.ts
@@ -19,8 +19,8 @@ export const findNftByMintOnChainOperationHandler: OperationHandler<FindNftByMin
       const [metadata, edition] = await metaplex
         .rpc()
         .getMultipleAccounts([
-          await MetadataAccount.pda(mint),
-          await OriginalOrPrintEditionAccount.pda(mint),
+          MetadataAccount.pda(mint),
+          OriginalOrPrintEditionAccount.pda(mint),
         ]);
 
       const metadataAccount = MetadataAccount.fromMaybe(metadata);

--- a/src/plugins/nftModule/findNftsByCandyMachine.ts
+++ b/src/plugins/nftModule/findNftsByCandyMachine.ts
@@ -29,7 +29,7 @@ export const findNftsByCandyMachineOnChainOperationHandler: OperationHandler<Fin
 
       if (version === 2) {
         // TODO: Refactor when we have a CandyMachine program in the SDK.
-        [firstCreator] = await PublicKey.findProgramAddress(
+        [firstCreator] = PublicKey.findProgramAddressSync(
           [Buffer.from('candy_machine'), candyMachine.toBuffer()],
           new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ')
         );

--- a/src/plugins/nftModule/findNftsByMintList.ts
+++ b/src/plugins/nftModule/findNftsByMintList.ts
@@ -21,9 +21,7 @@ export const findNftsByMintListOnChainOperationHandler: OperationHandler<FindNft
       metaplex: Metaplex
     ): Promise<(Nft | null)[]> => {
       const mints = operation.input;
-      const metadataPdas = await Promise.all(
-        mints.map((mint) => MetadataAccount.pda(mint))
-      );
+      const metadataPdas = mints.map((mint) => MetadataAccount.pda(mint));
       const metadataInfos = await GmaBuilder.make(metaplex, metadataPdas).get();
 
       return zipMap(

--- a/src/plugins/nftModule/printNewEdition.ts
+++ b/src/plugins/nftModule/printNewEdition.ts
@@ -83,8 +83,8 @@ export const printNewEditionOperationHandler: OperationHandler<PrintNewEditionOp
       } = operation.input;
 
       // Original NFT.
-      const originalMetadata = await MetadataAccount.pda(originalMint);
-      const originalEdition = await OriginalEditionAccount.pda(originalMint);
+      const originalMetadata = MetadataAccount.pda(originalMint);
+      const originalEdition = OriginalEditionAccount.pda(originalMint);
       const originalEditionAccount = OriginalEditionAccount.fromMaybe(
         await metaplex.rpc().getAccount(originalEdition)
       );
@@ -101,14 +101,14 @@ export const printNewEditionOperationHandler: OperationHandler<PrintNewEditionOp
       const edition = new BN(originalEditionAccount.data.supply, 'le').add(
         new BN(1)
       );
-      const originalEditionMarkPda = await EditionMarkerAccount.pda(
+      const originalEditionMarkPda = EditionMarkerAccount.pda(
         originalMint,
         edition
       );
 
       // New NFT.
-      const newMetadata = await MetadataAccount.pda(newMint.publicKey);
-      const newEdition = await PrintEditionAccount.pda(newMint.publicKey);
+      const newMetadata = MetadataAccount.pda(newMint.publicKey);
+      const newEdition = PrintEditionAccount.pda(newMint.publicKey);
       const lamports = await getMinimumBalanceForRentExemptMint(
         metaplex.connection
       );

--- a/src/plugins/nftModule/updateNft.ts
+++ b/src/plugins/nftModule/updateNft.ts
@@ -61,7 +61,7 @@ export const updateNftOperationHandler: OperationHandler<UpdateNftOperation> = {
 
     const data = resolveData(operation.input);
 
-    const metadata = await MetadataAccount.pda(nft.mint);
+    const metadata = MetadataAccount.pda(nft.mint);
 
     const { signature } = await metaplex.rpc().sendAndConfirmTransaction(
       updateNftBuilder({

--- a/src/plugins/nftModule/useEditionTask.ts
+++ b/src/plugins/nftModule/useEditionTask.ts
@@ -7,7 +7,7 @@ export type EditionTask = Task<OriginalOrPrintEditionAccount | null>;
 
 export const useEditionTask = (metaplex: Metaplex, nft: Nft): EditionTask =>
   useTask(async () => {
-    const pda = await OriginalOrPrintEditionAccount.pda(nft.mint);
+    const pda = OriginalOrPrintEditionAccount.pda(nft.mint);
     const edition = OriginalOrPrintEditionAccount.fromMaybe(
       await metaplex.rpc().getAccount(pda)
     );

--- a/src/programs/tokenMetadata/accounts/EditionMarkerAccount.ts
+++ b/src/programs/tokenMetadata/accounts/EditionMarkerAccount.ts
@@ -11,7 +11,7 @@ import {
 import { TokenMetadataProgram } from '../TokenMetadataProgram';
 
 export class EditionMarkerAccount extends BaseAccount<EditionMarker> {
-  static async pda(mint: PublicKey, edition: BN): Promise<Pda> {
+  static pda(mint: PublicKey, edition: BN): Pda {
     return Pda.find(TokenMetadataProgram.publicKey, [
       Buffer.from('metadata', 'utf8'),
       TokenMetadataProgram.publicKey.toBuffer(),

--- a/src/programs/tokenMetadata/accounts/MetadataAccount.ts
+++ b/src/programs/tokenMetadata/accounts/MetadataAccount.ts
@@ -10,7 +10,7 @@ import {
 import { TokenMetadataProgram } from '../TokenMetadataProgram';
 
 export class MetadataAccount extends BaseAccount<Metadata> {
-  static async pda(mint: PublicKey): Promise<Pda> {
+  static pda(mint: PublicKey): Pda {
     return Pda.find(TokenMetadataProgram.publicKey, [
       Buffer.from('metadata', 'utf8'),
       TokenMetadataProgram.publicKey.toBuffer(),

--- a/src/programs/tokenMetadata/accounts/OriginalEditionAccount.ts
+++ b/src/programs/tokenMetadata/accounts/OriginalEditionAccount.ts
@@ -17,7 +17,7 @@ import { TokenMetadataProgram } from '../TokenMetadataProgram';
 export class OriginalEditionAccount extends BaseAccount<
   MasterEditionV1 | MasterEditionV2
 > {
-  static async pda(mint: PublicKey): Promise<Pda> {
+  static pda(mint: PublicKey): Pda {
     return Pda.find(TokenMetadataProgram.publicKey, [
       Buffer.from('metadata', 'utf8'),
       TokenMetadataProgram.publicKey.toBuffer(),

--- a/src/programs/tokenMetadata/accounts/OriginalOrPrintEditionAccount.ts
+++ b/src/programs/tokenMetadata/accounts/OriginalOrPrintEditionAccount.ts
@@ -18,7 +18,7 @@ import { PrintEditionAccount } from './PrintEditionAccount';
 export class OriginalOrPrintEditionAccount extends BaseAccount<
   MasterEditionV1 | MasterEditionV2 | Edition
 > {
-  static async pda(mint: PublicKey): Promise<Pda> {
+  static pda(mint: PublicKey): Pda {
     return OriginalEditionAccount.pda(mint);
   }
 

--- a/src/programs/tokenMetadata/accounts/PrintEditionAccount.ts
+++ b/src/programs/tokenMetadata/accounts/PrintEditionAccount.ts
@@ -10,7 +10,7 @@ import {
 import { OriginalEditionAccount } from './OriginalEditionAccount';
 
 export class PrintEditionAccount extends BaseAccount<Edition> {
-  static async pda(mint: PublicKey): Promise<Pda> {
+  static pda(mint: PublicKey): Pda {
     return OriginalEditionAccount.pda(mint);
   }
 

--- a/src/types/Pda.ts
+++ b/src/types/Pda.ts
@@ -10,17 +10,11 @@ export class Pda extends PublicKey {
     this.bump = bump;
   }
 
-  static async find(
-    programId: PublicKey,
-    seeds: Array<Buffer | Uint8Array>
-  ): Promise<Pda> {
-    return this.fromPromise(PublicKey.findProgramAddress(seeds, programId));
-  }
-
-  static async fromPromise(
-    promise: Promise<[PublicKey, number]>
-  ): Promise<Pda> {
-    const [publicKey, bump] = await promise;
+  static find(programId: PublicKey, seeds: Array<Buffer | Uint8Array>): Pda {
+    const [publicKey, bump] = PublicKey.findProgramAddressSync(
+      seeds,
+      programId
+    );
 
     return new Pda(publicKey, bump);
   }

--- a/test/programs/tokenMetadata/createMetadataV2Builder.test.ts
+++ b/test/programs/tokenMetadata/createMetadataV2Builder.test.ts
@@ -26,7 +26,7 @@ test('it works when we give an explicit payer for the create metadata ix only', 
     mint.publicKey,
     mx.identity().publicKey
   );
-  const metadata = await MetadataAccount.pda(mint.publicKey);
+  const metadata = MetadataAccount.pda(mint.publicKey);
   const lamports = await getMinimumBalanceForRentExemptMint(mx.connection);
   const { uri } = await mx.nfts().uploadMetadata({ name: 'Metadata Name' });
   const data = {


### PR DESCRIPTION
Finding PDAs asynchronously makes little sense and, according to Solana documentation, has been kept for backward compatibility.

Instead, we should use `PublicKey.findProgramAddressSync` to find PDAs, which is what this PR does.